### PR TITLE
Feature: Implement Paint Bucket Mode

### DIFF
--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -21,7 +21,7 @@ import {
   PixelModifyItem,
 } from "./types";
 import { Indices } from "../../utils/types";
-import { validIndicesRange } from "../../utils/validation";
+import { isValidIndicesRange } from "../../utils/validation";
 import { addEvent, removeEvent, touchy, TouchyEvent } from "../../utils/touch";
 
 export enum MouseMode {
@@ -1012,7 +1012,7 @@ export default class Canvas extends EventDispatcher {
       /* 🪣 this paints same color area / with selected brush color. */
 
       const gridIndices = this.getGridIndices();
-      if (!validIndicesRange(rowIndex, columnIndex, gridIndices)) {
+      if (!isValidIndicesRange(rowIndex, columnIndex, gridIndices)) {
         return;
       }
 
@@ -1028,8 +1028,8 @@ export default class Canvas extends EventDispatcher {
         columnIndex,
       });
       this.emit(CanvasEvents.DATA_CHANGE, this.data);
+      this.emit(CanvasEvents.STROKE_END, this.strokedPixels, this.data);
     }
-
     this.render();
   }
 
@@ -1043,7 +1043,7 @@ export default class Canvas extends EventDispatcher {
 
     while (indicesQueue.size() > 0) {
       const { rowIndex, columnIndex } = indicesQueue.dequeue()!;
-      if (!validIndicesRange(rowIndex, columnIndex, gridIndices)) {
+      if (!isValidIndicesRange(rowIndex, columnIndex, gridIndices)) {
         continue;
       }
 

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -1053,6 +1053,11 @@ export default class Canvas extends EventDispatcher {
       }
 
       this.data.get(rowIndex)!.set(columnIndex, { color: this.brushColor });
+      this.strokedPixels.push({
+        rowIndex,
+        columnIndex,
+        color: this.brushColor,
+      });
       [
         { rowIndex: rowIndex - 1, columnIndex },
         { rowIndex: rowIndex + 1, columnIndex },

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -35,6 +35,7 @@ export enum CanvasEvents {
 export enum BrushMode {
   DOT = "dot",
   ERASER = "eraser",
+  PAINT_BUCKET = "paint bucket",
 }
 
 export type CanvasDataChangeHandler = (data: DottingData) => void;

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -1,0 +1,47 @@
+class QueueNode<T> {
+  data: T;
+  next: QueueNode<T> | null;
+
+  constructor(data: T) {
+    this.data = data;
+    this.next = null;
+  }
+}
+
+export default class Queue<T> {
+  private length: number;
+  private head: QueueNode<T> | null;
+  private tail: QueueNode<T> | null;
+
+  constructor() {
+    this.head = null;
+    this.tail = null;
+    this.length = 0;
+  }
+
+  enqueue(data: T): void {
+    const node = new QueueNode(data);
+    if (this.length === 0) {
+      this.head = node;
+    } else {
+      this.tail!.next = node;
+    }
+    this.tail = node;
+    this.length++;
+  }
+
+  dequeue(): T | null {
+    if (this.length === 0) {
+      return null;
+    }
+    const data = this.head.data;
+    this.head = this.head.next;
+    this.length--;
+
+    return data;
+  }
+
+  size(): number {
+    return this.length;
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -7,3 +7,10 @@ export type PanZoom = {
   scale: number;
   offset: Coord;
 };
+
+export type Indices = {
+  topRowIndex: number;
+  bottomRowIndex: number;
+  leftColumnIndex: number;
+  rightColumnIndex: number;
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,6 +1,6 @@
 import { Indices } from "./types";
 
-export function validIndicesRange(
+export function isValidIndicesRange(
   rowIndex: number,
   columnIndex: number,
   indices: Indices

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,17 @@
+import { Indices } from "./types";
+
+export function validIndicesRange(
+  rowIndex: number,
+  columnIndex: number,
+  indices: Indices
+) {
+  const { topRowIndex, bottomRowIndex, leftColumnIndex, rightColumnIndex } =
+    indices;
+
+  return !(
+    rowIndex < topRowIndex ||
+    rowIndex > bottomRowIndex ||
+    columnIndex < leftColumnIndex ||
+    columnIndex > rightColumnIndex
+  );
+}

--- a/stories/useBrush.stories.mdx
+++ b/stories/useBrush.stories.mdx
@@ -226,13 +226,14 @@ With `useBrush`, you can change the brush color and mode.
     </tr>
     <tr>
       <td>`changeBrushMode(brushMode: BrushMode)`</td>
-      <td>Allows you to change the brush mode to `DOT` or `ERASER`</td>
+      <td>Allows you to change the brush mode to `DOT`, `ERASER` or `PAINT_BUCKET`</td>
       <td>
         `BrushMode`
         ```ts
         export enum BrushMode {
           DOT = "dot",
           ERASER = "eraser",
+          PAINT_BUCKET = "paint bucket",
         }
         ```
       </td>

--- a/stories/useBrushComponents/ChangeBrushMode.tsx
+++ b/stories/useBrushComponents/ChangeBrushMode.tsx
@@ -6,7 +6,16 @@ import useBrush from "../../src/hooks/useBrush";
 
 const ChangeBrushMode = () => {
   const ref = useRef<DottingRef>(null);
-  const { changeBrushColor, changeBrushMode, brushMode } = useBrush(ref);
+  const { changeBrushColor, changeBrushMode, brushMode, brushColor } =
+    useBrush(ref);
+
+  const handleColorChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      changeBrushColor.bind(null, e.target.value)();
+    },
+    []
+  );
+
   return (
     <div
       style={{
@@ -39,7 +48,31 @@ const ChangeBrushMode = () => {
         >
           <option value={BrushMode.DOT}>{BrushMode.DOT}</option>
           <option value={BrushMode.ERASER}>{BrushMode.ERASER}</option>
+          <option value={BrushMode.PAINT_BUCKET}>
+            {BrushMode.PAINT_BUCKET}
+          </option>
         </select>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          marginTop: 10,
+          marginBottom: 3,
+        }}
+      >
+        <span style={{ fontSize: 13 }}>Brush Color</span>
+        <div
+          style={{
+            borderRadius: "50%",
+            width: 20,
+            height: 20,
+            marginLeft: 15,
+            marginRight: 15,
+            backgroundColor: brushColor,
+          }}
+        ></div>
+        <input type="color" value={brushColor} onChange={handleColorChange} />
       </div>
       <div></div>
     </div>


### PR DESCRIPTION
🚀 [Issue #3]
## Changes
### 🪣 Paint Bucket (BrushMode)
* **paint bucket brush mode** was added. (The implementation is in `drawPixel` method)
* **To Optimize..**
When thinking about how to search same color pixels, If the number of pixels increases, there are concerns about call stack accumulation. so I implemented it with BFS which looking at the adjacent pixels first.
(We couldn't enque at constant time with array. Queue is implemented in `utils/queue.ts`.)


### 🍓 Modify DOCS (useBrush story)
* [hooks] `useBrush` has been modified to reflect the relevant information. 

## Notes
* If brush mode is added more, how about managing it with a map in the form of `[mode name]: Function` to make it easier to manage? (I thought the idea of a **strategy pattern**, I'm going to look for related content more..!)
* If there's anything I'm missing or need to correct please leave a comment. Thank you for reading

## ScreenShot
![paint-bucket](https://user-images.githubusercontent.com/71599639/229096803-b0108a81-99bc-4bd0-b881-f238ca2a1480.gif)

