### PR TITLE
Fix: Minor bugs in undo/redo and colorPixels

### DIFF
--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -1272,7 +1272,10 @@ export default class Canvas extends EventDispatcher {
         });
       }
 
-      if (this.data.get(rowIndex)!.get(columnIndex).color !== this.brushColor) {
+      if (
+        this.data.get(rowIndex)!.get(columnIndex) &&
+        this.data.get(rowIndex)!.get(columnIndex).color !== this.brushColor
+      ) {
         this.fillPixelColor(rowIndex, columnIndex, this.brushColor);
         this.emit(CanvasEvents.DATA_CHANGE, this.data);
       }

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -895,11 +895,13 @@ export default class Canvas extends EventDispatcher {
     const allColumnKeys = Array.from(this.data.get(allRowKeys[0])!.keys());
     const currentTopIndex = Math.min(...allRowKeys);
     const currentLeftIndex = Math.min(...allColumnKeys);
+    const currentBottomIndex = Math.max(...allRowKeys);
+    const currentRightIndex = Math.max(...allColumnKeys);
     return {
       topRowIndex: currentTopIndex,
-      bottomRowIndex: currentTopIndex + allRowKeys.length - 1,
+      bottomRowIndex: currentBottomIndex,
       leftColumnIndex: currentLeftIndex,
-      rightColumnIndex: currentLeftIndex + allColumnKeys.length - 1,
+      rightColumnIndex: currentRightIndex,
     };
   }
 
@@ -950,7 +952,7 @@ export default class Canvas extends EventDispatcher {
     const minRowIndex = Math.min(...rowIndices);
     const maxRowIndex = Math.max(...rowIndices);
     const minColumnIndex = Math.min(...columnIndices);
-    const maxColumnIndex = Math.min(...columnIndices);
+    const maxColumnIndex = Math.max(...columnIndices);
     const currentCanvasIndices = this.getGridIndices();
     const changeAmounts = [];
     if (minRowIndex < currentCanvasIndices.topRowIndex) {
@@ -1013,7 +1015,6 @@ export default class Canvas extends EventDispatcher {
         amount,
       });
     }
-
     for (const change of data) {
       this.data
         .get(change.rowIndex)!
@@ -1272,6 +1273,9 @@ export default class Canvas extends EventDispatcher {
         });
       }
 
+      // console.log(rowIndex, columnIndex, this.brushColor, "coloring!");
+      // console.log(this.data.get(rowIndex)!.get(columnIndex));
+
       if (
         this.data.get(rowIndex)!.get(columnIndex) &&
         this.data.get(rowIndex)!.get(columnIndex).color !== this.brushColor
@@ -1434,14 +1438,11 @@ export default class Canvas extends EventDispatcher {
   };
 
   extendGrid(direction: ButtonDirection) {
-    const currentRowCount = this.getRowCount();
-    const currentColumnCount = this.getColumnCount();
-    const allRowKeys = Array.from(this.data.keys());
-    const allColumnKeys = Array.from(this.data.get(allRowKeys[0])!.keys());
-    const currentTopIndex = Math.min(...allRowKeys);
-    const currentLeftIndex = Math.min(...allColumnKeys);
-    const currentBottomIndex = currentTopIndex + currentRowCount - 1;
-    const currentRightIndex = currentLeftIndex + currentColumnCount - 1;
+    const gridIndices = this.getGridIndices();
+    const currentTopIndex = gridIndices.topRowIndex;
+    const currentLeftIndex = gridIndices.leftColumnIndex;
+    const currentBottomIndex = gridIndices.bottomRowIndex;
+    const currentRightIndex = gridIndices.rightColumnIndex;
 
     switch (direction) {
       case ButtonDirection.TOP:
@@ -1476,9 +1477,9 @@ export default class Canvas extends EventDispatcher {
         break;
       case ButtonDirection.LEFT:
         const newLeftIndex = currentLeftIndex - 1;
-        this.data.forEach((row) => {
-          row.set(newLeftIndex, { color: "" });
-        });
+        for (let i = currentTopIndex; i <= currentBottomIndex; i++) {
+          this.data.get(i)!.set(newLeftIndex, { color: "" });
+        }
         this.setPanZoom({
           offset: {
             x:
@@ -1491,9 +1492,9 @@ export default class Canvas extends EventDispatcher {
         break;
       case ButtonDirection.RIGHT:
         const newRightIndex = currentRightIndex + 1;
-        this.data.forEach((row) => {
-          row.set(newRightIndex, { color: "" });
-        });
+        for (let i = currentTopIndex; i <= currentBottomIndex; i++) {
+          this.data.get(i)!.set(newRightIndex, { color: "" });
+        }
         this.setPanZoom({
           offset: {
             x:

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -287,7 +287,13 @@ export default class Canvas extends EventDispatcher {
           }
         }
         // we do not need to care for colorchangemode.Erase since the grids are already deleted
-        if (colorSizeChangeAction.mode === ColorChangeMode.Fill) {
+        if (colorSizeChangeAction.mode === ColorChangeMode.Erase) {
+          const pixelsToFill = colorSizeChangeAction.data;
+          for (let i = 0; i < pixelsToFill.length; i++) {
+            const pixel = pixelsToFill[i];
+            this.fillPixelColor(pixel.rowIndex, pixel.columnIndex, "");
+          }
+        } else if (colorSizeChangeAction.mode === ColorChangeMode.Fill) {
           const pixelsToFill = colorSizeChangeAction.data;
           for (let i = 0; i < pixelsToFill.length; i++) {
             const pixel = pixelsToFill[i];
@@ -1345,6 +1351,7 @@ export default class Canvas extends EventDispatcher {
 
   onMouseDown(evt: TouchyEvent) {
     evt.preventDefault();
+
     const point = this.getPointFromTouchyEvent(evt);
     this.panPoint.lastMousePos = { x: point.offsetX, y: point.offsetY };
 

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -733,6 +733,7 @@ export default class Canvas extends EventDispatcher {
               squareLength
             );
             ctx.restore();
+            continue;
           }
         }
         if (


### PR DESCRIPTION
🚀 [Related Issue: #]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Fix bugs in undo/redo

- **[🎨Component] Undo/Redo for ColorSizeChangeAction has been updated**

  - Previously, ColorSizeChangeAction did not erase correctly

## Fix bugs in colorPixels

- **[🎨Component] Fix maxColumnCount**

  - Previously, colorPixels did not work well when the columnIndex was bigger than the current rightColumnIndex. This was due to the use of `Math.min` instead of `Math.max`


<br/>

## Notes

- This is a quick fix for dotting-genai.

<br/>

## Next Up?

