### PR TITLE
Feature/extend grid interaction

### DIFF
--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -4,6 +4,7 @@ import {
   diffPoints,
   getScreenPoint,
   getWorldPoint,
+  lerp,
 } from "../../utils/math";
 import React from "react";
 import Queue from "../../utils/queue";
@@ -430,7 +431,7 @@ export default class Canvas extends EventDispatcher {
     ctx.save();
     const buttonPos: Coord = {
       x: -gridsWidth / 2,
-      y: -gridsHeight / 2 - this.buttonMargin,
+      y: -gridsHeight / 2,
     };
     const convertedScreenPoint = convertCartesianToScreen(
       this.element,
@@ -441,28 +442,36 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
+
+    const scaledButtonHeight = lerp(
+      this.panZoom.scale,
+      [this.MAX_SCALE, this.MIN_SCALE],
+      [1, this.buttonHeight],
+    );
+
     ctx.fillStyle = color;
     ctx.fillRect(
       correctedScreenPoint.x,
-      correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.y - (scaledButtonHeight / 2) * this.panZoom.scale,
       gridsWidth * this.panZoom.scale,
-      this.buttonHeight * this.panZoom.scale,
+      scaledButtonHeight * this.panZoom.scale,
     );
     ctx.restore();
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-      correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
-      Math.PI * 2,
-      this.panZoom.scale,
-    );
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-      correctedScreenPoint.y + (this.buttonHeight / 2) * this.panZoom.scale,
-      Math.PI,
-      this.panZoom.scale,
-    );
+
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
+    //   correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
+    //   Math.PI * 2,
+    //   this.panZoom.scale,
+    // );
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
+    //   correctedScreenPoint.y + (this.buttonHeight / 2) * this.panZoom.scale,
+    //   Math.PI,
+    //   this.panZoom.scale,
+    // );
   }
 
   drawBottomButton(color: string) {

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -342,20 +342,20 @@ export default class Canvas extends EventDispatcher {
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const topButtonPos: Coord = {
       x: -gridsWidth / 2,
-      y: -gridsHeight / 2 - this.buttonHeight / 2,
+      y: -gridsHeight / 2 - this.buttonMargin - this.buttonHeight / 2,
     };
     const bottomButtonPos: Coord = {
       x: -gridsWidth / 2,
-      y: gridsHeight / 2 - this.buttonHeight / 2,
+      y: gridsHeight / 2 + this.buttonMargin - this.buttonHeight / 2,
     };
 
     const leftButtonPos: Coord = {
-      x: -gridsWidth / 2 - this.buttonHeight / 2,
+      x: -gridsWidth / 2 - this.buttonMargin - this.buttonHeight / 2,
       y: -gridsHeight / 2,
     };
 
     const rightButtonPos: Coord = {
-      x: gridsWidth / 2 - this.buttonHeight / 2,
+      x: gridsWidth / 2 + this.buttonMargin - this.buttonHeight / 2,
       y: -gridsHeight / 2,
     };
 
@@ -368,25 +368,25 @@ export default class Canvas extends EventDispatcher {
     const x = coord.x;
     const y = coord.y;
     const topButtonRect = {
-      x: topButtonPos.x - this.buttonHeight / 2,
+      x: topButtonPos.x,
       y: topButtonPos.y,
       width: gridsWidth,
       height: scaledButtonHeight,
     };
     const bottomButtonRect = {
       x: bottomButtonPos.x,
-      y: bottomButtonPos.y + this.buttonHeight / 2,
+      y: bottomButtonPos.y,
       width: gridsWidth,
       height: scaledButtonHeight,
     };
     const leftButtonRect = {
-      x: leftButtonPos.x - this.buttonHeight / 2,
+      x: leftButtonPos.x,
       y: leftButtonPos.y,
       width: scaledButtonHeight,
       height: gridsHeight,
     };
     const rightButtonRect = {
-      x: rightButtonPos.x + this.buttonHeight / 2,
+      x: rightButtonPos.x,
       y: rightButtonPos.y,
       width: scaledButtonHeight,
       height: gridsHeight,
@@ -448,9 +448,7 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
-
     ctx.fillStyle = color;
-    ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x,
       correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
@@ -478,9 +476,7 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
-
     ctx.fillStyle = color;
-    ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x,
       correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
@@ -509,9 +505,7 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
-
     ctx.fillStyle = color;
-    ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
       correctedScreenPoint.y,
@@ -539,9 +533,7 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
-
     ctx.fillStyle = color;
-    ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
       correctedScreenPoint.y,

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -765,7 +765,8 @@ export default class Canvas extends EventDispatcher {
         if (
           this.hoveredPixel &&
           this.hoveredPixel.rowIndex === rowIndex &&
-          this.hoveredPixel.columnIndex === columnIndex
+          this.hoveredPixel.columnIndex === columnIndex &&
+          this.mouseMode !== MouseMode.EXTENDING
         ) {
           ctx.save();
           const { rowIndex, columnIndex } = this.hoveredPixel;
@@ -1376,7 +1377,7 @@ export default class Canvas extends EventDispatcher {
 
     const mouseCartCoord = this.getMouseCartCoord(evt);
     const pixelIndex = this.getPixelIndexFromMouseCartCoord(mouseCartCoord);
-    if (pixelIndex) {
+    if (pixelIndex && !this.hoveredButton) {
       this.emit(CanvasEvents.HOVER_PIXEL_CHANGE, null);
       this.drawPixel(pixelIndex.rowIndex, pixelIndex.columnIndex);
     }

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -362,31 +362,31 @@ export default class Canvas extends EventDispatcher {
     const scaledButtonHeight = lerp(
       this.panZoom.scale,
       [this.MAX_SCALE, this.MIN_SCALE],
-      [5, this.buttonHeight],
+      [this.buttonHeight, this.buttonHeight * 2],
     );
 
     const x = coord.x;
     const y = coord.y;
     const topButtonRect = {
-      x: topButtonPos.x,
+      x: topButtonPos.x - this.buttonHeight / 2,
       y: topButtonPos.y,
       width: gridsWidth,
       height: scaledButtonHeight,
     };
     const bottomButtonRect = {
       x: bottomButtonPos.x,
-      y: bottomButtonPos.y,
+      y: bottomButtonPos.y + this.buttonHeight / 2,
       width: gridsWidth,
       height: scaledButtonHeight,
     };
     const leftButtonRect = {
-      x: leftButtonPos.x,
+      x: leftButtonPos.x - this.buttonHeight / 2,
       y: leftButtonPos.y,
       width: scaledButtonHeight,
       height: gridsHeight,
     };
     const rightButtonRect = {
-      x: rightButtonPos.x,
+      x: rightButtonPos.x + this.buttonHeight / 2,
       y: rightButtonPos.y,
       width: scaledButtonHeight,
       height: gridsHeight,
@@ -437,7 +437,7 @@ export default class Canvas extends EventDispatcher {
     ctx.save();
     const buttonPos: Coord = {
       x: -gridsWidth / 2,
-      y: -gridsHeight / 2,
+      y: -gridsHeight / 2 - this.buttonMargin,
     };
     const convertedScreenPoint = convertCartesianToScreen(
       this.element,
@@ -449,36 +449,15 @@ export default class Canvas extends EventDispatcher {
       this.panZoom,
     );
 
-    const scaledButtonHeight = lerp(
-      this.panZoom.scale,
-      [this.MAX_SCALE, this.MIN_SCALE],
-      [5, this.buttonHeight],
-    );
-
     ctx.fillStyle = color;
     ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x,
-      correctedScreenPoint.y - (scaledButtonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
       gridsWidth * this.panZoom.scale,
-      scaledButtonHeight * this.panZoom.scale,
+      this.buttonHeight * this.panZoom.scale,
     );
     ctx.restore();
-
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-    //   correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
-    //   Math.PI * 2,
-    //   this.panZoom.scale,
-    // );
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-    //   correctedScreenPoint.y + (this.buttonHeight / 2) * this.panZoom.scale,
-    //   Math.PI,
-    //   this.panZoom.scale,
-    // );
   }
 
   drawBottomButton(color: string) {
@@ -488,7 +467,7 @@ export default class Canvas extends EventDispatcher {
     const gridsHeight = this.gridSquareLength * this.getRowCount();
     const buttonPos: Coord = {
       x: -gridsWidth / 2,
-      y: gridsHeight / 2,
+      y: gridsHeight / 2 + this.buttonMargin,
     };
     const convertedScreenPoint = convertCartesianToScreen(
       this.element,
@@ -500,47 +479,14 @@ export default class Canvas extends EventDispatcher {
       this.panZoom,
     );
 
-    const scaledButtonHeight = lerp(
-      this.panZoom.scale,
-      [this.MAX_SCALE, this.MIN_SCALE],
-      [5, this.buttonHeight],
-    );
-
     ctx.fillStyle = color;
     ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x,
-      correctedScreenPoint.y - (scaledButtonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
       gridsWidth * this.panZoom.scale,
-      scaledButtonHeight * this.panZoom.scale,
+      this.buttonHeight * this.panZoom.scale,
     );
-    ctx.restore();
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-    //   correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
-    //   Math.PI * 2,
-    //   this.panZoom.scale,
-    // );
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-    //   correctedScreenPoint.y + (this.buttonHeight / 2) * this.panZoom.scale,
-    //   Math.PI,
-    //   this.panZoom.scale,
-    // );
-  }
-  drawArrowHead(ctx, x, y, radians, scale) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.translate(x, y);
-    ctx.rotate(radians);
-    ctx.moveTo(0, 0);
-    ctx.lineTo(7 * scale, 5 * scale);
-    ctx.lineTo(-7 * scale, 5 * scale);
-    ctx.closePath();
-    ctx.fillStyle = "#949494";
-    ctx.fill();
     ctx.restore();
   }
 
@@ -551,7 +497,7 @@ export default class Canvas extends EventDispatcher {
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
     const buttonPos: Coord = {
-      x: -gridsWidth / 2,
+      x: -gridsWidth / 2 - this.buttonMargin,
       y: -gridsHeight / 2,
     };
     const convertedScreenPoint = convertCartesianToScreen(
@@ -564,35 +510,15 @@ export default class Canvas extends EventDispatcher {
       this.panZoom,
     );
 
-    const scaledButtonHeight = lerp(
-      this.panZoom.scale,
-      [this.MAX_SCALE, this.MIN_SCALE],
-      [5, this.buttonHeight],
-    );
-
     ctx.fillStyle = color;
     ctx.globalAlpha = 0.8;
     ctx.fillRect(
-      correctedScreenPoint.x - (scaledButtonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
       correctedScreenPoint.y,
-      scaledButtonHeight * this.panZoom.scale,
+      this.buttonHeight * this.panZoom.scale,
       gridsHeight * this.panZoom.scale,
     );
     ctx.restore();
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
-    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-    //   -Math.PI / 2,
-    //   this.panZoom.scale,
-    // );
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x + (this.buttonHeight / 2) * this.panZoom.scale,
-    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-    //   Math.PI / 2,
-    //   this.panZoom.scale,
-    // );
   }
 
   drawRightButton(color: string) {
@@ -601,7 +527,7 @@ export default class Canvas extends EventDispatcher {
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
     const buttonPos: Coord = {
-      x: gridsWidth / 2,
+      x: gridsWidth / 2 + this.buttonMargin,
       y: -gridsHeight / 2,
     };
     const convertedScreenPoint = convertCartesianToScreen(
@@ -614,35 +540,15 @@ export default class Canvas extends EventDispatcher {
       this.panZoom,
     );
 
-    const scaledButtonHeight = lerp(
-      this.panZoom.scale,
-      [this.MAX_SCALE, this.MIN_SCALE],
-      [5, this.buttonHeight],
-    );
-
     ctx.fillStyle = color;
     ctx.globalAlpha = 0.8;
     ctx.fillRect(
-      correctedScreenPoint.x - (scaledButtonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
       correctedScreenPoint.y,
-      scaledButtonHeight * this.panZoom.scale,
+      this.buttonHeight * this.panZoom.scale,
       gridsHeight * this.panZoom.scale,
     );
     ctx.restore();
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
-    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-    //   -Math.PI / 2,
-    //   this.panZoom.scale,
-    // );
-    // this.drawArrowHead(
-    //   ctx,
-    //   correctedScreenPoint.x + (this.buttonHeight / 2) * this.panZoom.scale,
-    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-    //   Math.PI / 2,
-    //   this.panZoom.scale,
-    // );
   }
 
   drawButtons() {

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -342,22 +342,28 @@ export default class Canvas extends EventDispatcher {
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const topButtonPos: Coord = {
       x: -gridsWidth / 2,
-      y: -gridsHeight / 2 - this.buttonMargin - this.buttonHeight / 2,
+      y: -gridsHeight / 2 - this.buttonHeight / 2,
     };
     const bottomButtonPos: Coord = {
       x: -gridsWidth / 2,
-      y: gridsHeight / 2 + this.buttonMargin - this.buttonHeight / 2,
+      y: gridsHeight / 2 - this.buttonHeight / 2,
     };
 
     const leftButtonPos: Coord = {
-      x: -gridsWidth / 2 - this.buttonMargin - this.buttonHeight / 2,
+      x: -gridsWidth / 2 - this.buttonHeight / 2,
       y: -gridsHeight / 2,
     };
 
     const rightButtonPos: Coord = {
-      x: gridsWidth / 2 + this.buttonMargin - this.buttonHeight / 2,
+      x: gridsWidth / 2 - this.buttonHeight / 2,
       y: -gridsHeight / 2,
     };
+
+    const scaledButtonHeight = lerp(
+      this.panZoom.scale,
+      [this.MAX_SCALE, this.MIN_SCALE],
+      [5, this.buttonHeight],
+    );
 
     const x = coord.x;
     const y = coord.y;
@@ -365,24 +371,24 @@ export default class Canvas extends EventDispatcher {
       x: topButtonPos.x,
       y: topButtonPos.y,
       width: gridsWidth,
-      height: this.buttonHeight,
+      height: scaledButtonHeight,
     };
     const bottomButtonRect = {
       x: bottomButtonPos.x,
       y: bottomButtonPos.y,
       width: gridsWidth,
-      height: this.buttonHeight,
+      height: scaledButtonHeight,
     };
     const leftButtonRect = {
       x: leftButtonPos.x,
       y: leftButtonPos.y,
-      width: this.buttonHeight,
+      width: scaledButtonHeight,
       height: gridsHeight,
     };
     const rightButtonRect = {
       x: rightButtonPos.x,
       y: rightButtonPos.y,
-      width: this.buttonHeight,
+      width: scaledButtonHeight,
       height: gridsHeight,
     };
 
@@ -446,10 +452,11 @@ export default class Canvas extends EventDispatcher {
     const scaledButtonHeight = lerp(
       this.panZoom.scale,
       [this.MAX_SCALE, this.MIN_SCALE],
-      [1, this.buttonHeight],
+      [5, this.buttonHeight],
     );
 
     ctx.fillStyle = color;
+    ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x,
       correctedScreenPoint.y - (scaledButtonHeight / 2) * this.panZoom.scale,
@@ -481,7 +488,7 @@ export default class Canvas extends EventDispatcher {
     const gridsHeight = this.gridSquareLength * this.getRowCount();
     const buttonPos: Coord = {
       x: -gridsWidth / 2,
-      y: gridsHeight / 2 + this.buttonMargin,
+      y: gridsHeight / 2,
     };
     const convertedScreenPoint = convertCartesianToScreen(
       this.element,
@@ -492,28 +499,36 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
+
+    const scaledButtonHeight = lerp(
+      this.panZoom.scale,
+      [this.MAX_SCALE, this.MIN_SCALE],
+      [5, this.buttonHeight],
+    );
+
     ctx.fillStyle = color;
+    ctx.globalAlpha = 0.8;
     ctx.fillRect(
       correctedScreenPoint.x,
-      correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.y - (scaledButtonHeight / 2) * this.panZoom.scale,
       gridsWidth * this.panZoom.scale,
-      this.buttonHeight * this.panZoom.scale,
+      scaledButtonHeight * this.panZoom.scale,
     );
     ctx.restore();
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-      correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
-      Math.PI * 2,
-      this.panZoom.scale,
-    );
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
-      correctedScreenPoint.y + (this.buttonHeight / 2) * this.panZoom.scale,
-      Math.PI,
-      this.panZoom.scale,
-    );
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
+    //   correctedScreenPoint.y - (this.buttonHeight / 2) * this.panZoom.scale,
+    //   Math.PI * 2,
+    //   this.panZoom.scale,
+    // );
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x + (gridsWidth * this.panZoom.scale) / 2,
+    //   correctedScreenPoint.y + (this.buttonHeight / 2) * this.panZoom.scale,
+    //   Math.PI,
+    //   this.panZoom.scale,
+    // );
   }
   drawArrowHead(ctx, x, y, radians, scale) {
     ctx.save();
@@ -536,7 +551,7 @@ export default class Canvas extends EventDispatcher {
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
     const buttonPos: Coord = {
-      x: -gridsWidth / 2 - this.buttonMargin,
+      x: -gridsWidth / 2,
       y: -gridsHeight / 2,
     };
     const convertedScreenPoint = convertCartesianToScreen(
@@ -549,28 +564,35 @@ export default class Canvas extends EventDispatcher {
       this.panZoom,
     );
 
+    const scaledButtonHeight = lerp(
+      this.panZoom.scale,
+      [this.MAX_SCALE, this.MIN_SCALE],
+      [5, this.buttonHeight],
+    );
+
     ctx.fillStyle = color;
+    ctx.globalAlpha = 0.8;
     ctx.fillRect(
-      correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.x - (scaledButtonHeight / 2) * this.panZoom.scale,
       correctedScreenPoint.y,
-      this.buttonHeight * this.panZoom.scale,
+      scaledButtonHeight * this.panZoom.scale,
       gridsHeight * this.panZoom.scale,
     );
     ctx.restore();
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
-      correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-      -Math.PI / 2,
-      this.panZoom.scale,
-    );
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x + (this.buttonHeight / 2) * this.panZoom.scale,
-      correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-      Math.PI / 2,
-      this.panZoom.scale,
-    );
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
+    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
+    //   -Math.PI / 2,
+    //   this.panZoom.scale,
+    // );
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x + (this.buttonHeight / 2) * this.panZoom.scale,
+    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
+    //   Math.PI / 2,
+    //   this.panZoom.scale,
+    // );
   }
 
   drawRightButton(color: string) {
@@ -579,7 +601,7 @@ export default class Canvas extends EventDispatcher {
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
     const buttonPos: Coord = {
-      x: gridsWidth / 2 + this.buttonMargin,
+      x: gridsWidth / 2,
       y: -gridsHeight / 2,
     };
     const convertedScreenPoint = convertCartesianToScreen(
@@ -591,28 +613,36 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
+
+    const scaledButtonHeight = lerp(
+      this.panZoom.scale,
+      [this.MAX_SCALE, this.MIN_SCALE],
+      [5, this.buttonHeight],
+    );
+
     ctx.fillStyle = color;
+    ctx.globalAlpha = 0.8;
     ctx.fillRect(
-      correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
+      correctedScreenPoint.x - (scaledButtonHeight / 2) * this.panZoom.scale,
       correctedScreenPoint.y,
-      this.buttonHeight * this.panZoom.scale,
+      scaledButtonHeight * this.panZoom.scale,
       gridsHeight * this.panZoom.scale,
     );
     ctx.restore();
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
-      correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-      -Math.PI / 2,
-      this.panZoom.scale,
-    );
-    this.drawArrowHead(
-      ctx,
-      correctedScreenPoint.x + (this.buttonHeight / 2) * this.panZoom.scale,
-      correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
-      Math.PI / 2,
-      this.panZoom.scale,
-    );
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
+    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
+    //   -Math.PI / 2,
+    //   this.panZoom.scale,
+    // );
+    // this.drawArrowHead(
+    //   ctx,
+    //   correctedScreenPoint.x + (this.buttonHeight / 2) * this.panZoom.scale,
+    //   correctedScreenPoint.y + (gridsHeight * this.panZoom.scale) / 2,
+    //   Math.PI / 2,
+    //   this.panZoom.scale,
+    // );
   }
 
   drawButtons() {

--- a/src/components/Canvas/index.ts
+++ b/src/components/Canvas/index.ts
@@ -50,6 +50,8 @@ export default class Canvas extends EventDispatcher {
 
   private MIN_SCALE = 0.3;
 
+  private extensionAllowanceRatio = 3;
+
   private ZOOM_SENSITIVITY = 200;
 
   private buttonHeight = 20;
@@ -341,35 +343,32 @@ export default class Canvas extends EventDispatcher {
   detectMouseOnButton(coord: Coord): ButtonDirection | null {
     const gridsHeight = this.gridSquareLength * this.getRowCount();
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
-    const topButtonPos: Coord = {
-      x: -gridsWidth / 2,
-      y: -gridsHeight / 2 - this.buttonMargin - this.buttonHeight / 2,
-    };
-    const bottomButtonPos: Coord = {
-      x: -gridsWidth / 2,
-      y: gridsHeight / 2 + this.buttonMargin - this.buttonHeight / 2,
-    };
-
-    const leftButtonPos: Coord = {
-      x: -gridsWidth / 2 - this.buttonMargin - this.buttonHeight / 2,
-      y: -gridsHeight / 2,
-    };
-
-    const rightButtonPos: Coord = {
-      x: gridsWidth / 2 + this.buttonMargin - this.buttonHeight / 2,
-      y: -gridsHeight / 2,
-    };
-
-    const rightTopButtonPos: Coord = {
-      x: gridsWidth / 2 + this.buttonMargin - this.buttonHeight / 2,
-      y: -gridsHeight / 2 - this.buttonMargin - this.buttonHeight / 2,
-    };
-
     const scaledButtonHeight = lerp(
       this.panZoom.scale,
       [this.MAX_SCALE, this.MIN_SCALE],
-      [this.buttonHeight, this.buttonHeight * 2],
+      [this.buttonHeight, this.buttonHeight * this.extensionAllowanceRatio],
     );
+
+    const topButtonPos: Coord = {
+      x: -gridsWidth / 2,
+      y: -gridsHeight / 2 - this.buttonMargin - scaledButtonHeight / 2,
+    };
+    const bottomButtonPos: Coord = {
+      x: -gridsWidth / 2,
+      y: gridsHeight / 2 + this.buttonMargin - scaledButtonHeight / 2,
+    };
+    const leftButtonPos: Coord = {
+      x: -gridsWidth / 2 - this.buttonMargin - scaledButtonHeight / 2,
+      y: -gridsHeight / 2,
+    };
+    const rightButtonPos: Coord = {
+      x: gridsWidth / 2 + this.buttonMargin - scaledButtonHeight / 2,
+      y: -gridsHeight / 2,
+    };
+    const rightTopButtonPos: Coord = {
+      x: gridsWidth / 2 + this.buttonMargin - scaledButtonHeight / 2,
+      y: -gridsHeight / 2 - this.buttonMargin - scaledButtonHeight / 2,
+    };
 
     const x = coord.x;
     const y = coord.y;
@@ -452,8 +451,6 @@ export default class Canvas extends EventDispatcher {
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
 
-    const ctx = this.ctx;
-    ctx.save();
     const buttonPos: Coord = {
       x: -gridsWidth / 2,
       y: -gridsHeight / 2 - this.buttonMargin,
@@ -467,6 +464,9 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
+
+    const ctx = this.ctx;
+    ctx.save();
     ctx.fillStyle = color;
     ctx.fillRect(
       correctedScreenPoint.x,
@@ -478,10 +478,9 @@ export default class Canvas extends EventDispatcher {
   }
 
   drawBottomButton(color: string) {
-    const ctx = this.ctx;
-    ctx.save();
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
+
     const buttonPos: Coord = {
       x: -gridsWidth / 2,
       y: gridsHeight / 2 + this.buttonMargin,
@@ -495,6 +494,9 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
+
+    const ctx = this.ctx;
+    ctx.save();
     ctx.fillStyle = color;
     ctx.fillRect(
       correctedScreenPoint.x,
@@ -506,11 +508,9 @@ export default class Canvas extends EventDispatcher {
   }
 
   drawLeftButton(color: string) {
-    const ctx = this.ctx;
-
-    ctx.save();
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
+
     const buttonPos: Coord = {
       x: -gridsWidth / 2 - this.buttonMargin,
       y: -gridsHeight / 2,
@@ -524,6 +524,9 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
+
+    const ctx = this.ctx;
+    ctx.save();
     ctx.fillStyle = color;
     ctx.fillRect(
       correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,
@@ -535,10 +538,9 @@ export default class Canvas extends EventDispatcher {
   }
 
   drawRightButton(color: string) {
-    const ctx = this.ctx;
-    ctx.save();
     const gridsWidth = this.gridSquareLength * this.getColumnCount();
     const gridsHeight = this.gridSquareLength * this.getRowCount();
+
     const buttonPos: Coord = {
       x: gridsWidth / 2 + this.buttonMargin,
       y: -gridsHeight / 2,
@@ -552,6 +554,9 @@ export default class Canvas extends EventDispatcher {
       convertedScreenPoint,
       this.panZoom,
     );
+
+    const ctx = this.ctx;
+    ctx.save();
     ctx.fillStyle = color;
     ctx.fillRect(
       correctedScreenPoint.x - (this.buttonHeight / 2) * this.panZoom.scale,

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -98,3 +98,12 @@ export function worldPointToCartesian(point: Coord, panZoom: PanZoom): Coord {
     y: (point.y - offset.y) / scale,
   };
 }
+
+export function lerp(
+  value: number,
+  [range1Start, range1End]: number[],
+  [range2Start, range2End],
+) {
+  const ratio = (value - range1Start) / (range1End - range1Start);
+  return range2Start + (range2End - range2Start) * ratio;
+}


### PR DESCRIPTION
🚀 [Related Issue: #7 ]

### Preview

| larger extension activation area when zoomed out |
| --- |
| ![chrome-capture-2023-3-22](https://user-images.githubusercontent.com/76679207/233791298-34e65fa8-7025-4030-a370-d3eb7bcf5e6b.gif) |
| currently when zoomed out to max, extension activation area is tripled to button's height |

| corner extension | 
| --- |
| ![chrome-capture-2023-3-23](https://user-images.githubusercontent.com/76679207/233792118-2112c2e9-a757-450f-919f-35e0a170740a.gif) |

<br/>

##  Responsive extension activation area

- **[🎨Component]**

  - unable to draw new rects when extending via adding condition in `onMouseDown`
  - not rendering indicator rects when `MouseMode.EXTENDING`
  - removed arrowHeads
  - tested corner extension(right-top) -> just ditto of previous

- **[🔗Other]**

  - Added range lerp function to utils

<br/>

## Notes

- there should be a better way to implement corner extension, but if improving is redundant plz leave a comment, I'll just replicate all to left 3 corners. before this I'll leave this as a draft

<br/>
