### PR TITLE
Feature: User-friendly grid extension mechanism

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -296,7 +296,7 @@ export default class Editor extends EventDispatcher {
     const y = coord.y;
     const scaledYHeight = lerpRanges(
       this.panZoom.scale,
-      // this range is inverted because height has to smaller when zoom out
+      // this range is inverted because height has to be smaller when zoomed in
       this.maxScale,
       this.minScale,
       top.height,
@@ -304,7 +304,7 @@ export default class Editor extends EventDispatcher {
     );
     const scaledXWidth = lerpRanges(
       this.panZoom.scale,
-      // this range is inverted because width has to smaller when zoom out
+      // this range is inverted because width has to be smaller when zoomed in
       this.maxScale,
       this.minScale,
       left.width,
@@ -313,8 +313,8 @@ export default class Editor extends EventDispatcher {
     if (
       x >= top.x &&
       x <= top.x + top.width &&
-      y >= top.y - scaledYHeight &&
-      y <= top.y + scaledYHeight - scaledYHeight + top.height
+      y >= top.y - scaledYHeight + top.height &&
+      y <= top.y + top.height
     ) {
       return ButtonDirection.TOP;
     } else if (
@@ -325,8 +325,8 @@ export default class Editor extends EventDispatcher {
     ) {
       return ButtonDirection.BOTTOM;
     } else if (
-      x >= left.x - scaledXWidth &&
-      x <= left.x + scaledXWidth - scaledXWidth + left.width &&
+      x >= left.x - scaledXWidth + left.width &&
+      x <= left.x + left.width &&
       y >= left.y &&
       y <= left.y + left.height
     ) {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -98,3 +98,14 @@ export function worldPointToCartesian(point: Coord, panZoom: PanZoom): Coord {
     y: (point.y - offset.y) / scale,
   };
 }
+
+export function lerpRanges(
+  value: number,
+  range1Start: number,
+  range1End: number,
+  range2Start: number,
+  range2End: number,
+) {
+  const ratio = (value - range1Start) / (range1End - range1Start);
+  return range2Start + (range2End - range2Start) * ratio;
+}


### PR DESCRIPTION
🚀 [Related Issue: #7 ]

### Preview

![chrome-capture-2023-4-7](https://user-images.githubusercontent.com/76679207/236658821-7833146d-9595-403e-a8c6-b99673215744.gif)

<br/>

## Wider interactable area for extending grids

- **[🎨Component] updated position and width of detectable range in Editor.tsx**

  - `detectButtonClicked` : For bottom & left it's range was simply replaced with scaledRange but for top & right it is not pretty readable so leaving a pic for better understanding

![image](https://user-images.githubusercontent.com/76679207/236659447-6cebd4a3-ded3-4eaa-aac8-883ebc891b2b.png)

- **[🔗Other] Added lerpRanges function to math utils**

  - Since we have max & min scale range and it gets set by panZoom, lerping ranges from `scale.max ~ scale.min` and `width ~ width * extensionAllowanceRatio` results of variable width. 

<br/>