### PR TITLE
Allow brush tool to be none

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -1354,7 +1354,7 @@ export default class Editor extends EventDispatcher {
         // move the pixels to interaction layer
       }
     } else {
-      if (pixelIndex) {
+      if (pixelIndex && this.brushTool !== BrushTool.NONE) {
         this.emitHoverPixelChangeEvent({
           indices: null,
         });

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -41,6 +41,7 @@ export enum BrushTool {
   ERASER = "ERASER",
   PAINT_BUCKET = "PAINT_BUCKET",
   SELECT = "SELECT",
+  NONE = "NONE",
 }
 
 export type CanvasDataChangeParams = { data: DottingData };

--- a/stories/useBrush.stories.mdx
+++ b/stories/useBrush.stories.mdx
@@ -226,7 +226,7 @@ With `useBrush`, you can change the brush color and mode.
     </tr>
     <tr>
       <td>`changeBrushTool(brushTool: BrushTool)`</td>
-      <td>Allows you to change the brush mode to `DOT`, `ERASER` or `PAINT_BUCKET`</td>
+      <td>Allows you to change the brush mode to `DOT`, `ERASER`, `PAINT_BUCKET`, `SELECT`, or `NONE`</td>
       <td>
         `BrushTool`
         ```ts
@@ -234,6 +234,8 @@ With `useBrush`, you can change the brush color and mode.
           DOT = "DOT",
           ERASER = "ERASER",
           PAINT_BUCKET = "PAINT_BUCKET",
+          SELECT = "SELECT",
+          NONE = "NONE",
         }
         ```
       </td>


### PR DESCRIPTION
🚀 [Related Issue: #]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Write a title of your change

- **[🎨Component] Add `NONE` to `BrushTool`**

  - I added a `NONE` to `BrushTool` since this will be needed when we want users to customize the brush. When users use their custom brush, they would have to make the brush tool `NONE` and use `colorPixels` to modify the colors in the pixels.

- **[📒Docs] Update the brushtool table in `useBrush.stories.tsx`**

  - The brushtool was not updated so I updated it.


<br/>

## Notes



<br/>

## Next Up?

