### PR TITLE
Feature/improve extend

### DIFF
--- a/.github/workflows/gh-pages.deploy.yml
+++ b/.github/workflows/gh-pages.deploy.yml
@@ -23,10 +23,6 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
-          # The below two are based on the example from
-          # https://github.com/rossjrw/pr-preview-action
-          force: false
-          clean-exclude: pr-preview/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: storybook-static # The folder that the build-storybook script generates files.

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -1434,10 +1434,6 @@ export default class Editor extends EventDispatcher {
       if (!isGridFixed) {
         const buttonDirection = this.detectButtonClicked(mouseCartCoord);
         if (buttonDirection) {
-          // this.extensionPoint.lastMousePos = {
-          //   x: mouseCartCoord.x,
-          //   y: mouseCartCoord.y,
-          // };
           this.extensionPoint.direction = buttonDirection;
           this.mouseMode = MouseMode.EXTENDING;
           touchy(this.element, addEvent, "mousemove", this.handleExtension);

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -815,7 +815,7 @@ export default class Editor extends EventDispatcher {
 
   handleWheel = (e: WheelEvent) => {
     e.preventDefault();
-    if (!this.isPanZoomable) {
+    if (!this.isPanZoomable || this.mouseMode === MouseMode.EXTENDING) {
       return;
     }
     if (e.ctrlKey) {

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -255,7 +255,6 @@ export default class InteractionLayer extends BaseLayer {
       direction === ButtonDirection.BOTTOM
     ) {
       if (rowCount <= 2) {
-        console.log("row count less than 2");
         return false;
       }
       const swipedRowIndex =
@@ -272,7 +271,6 @@ export default class InteractionLayer extends BaseLayer {
       direction === ButtonDirection.RIGHT
     ) {
       if (columnCount <= 2) {
-        console.log("column count less than 2");
         return false;
       }
       const swipedColumnIndex =

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -78,6 +78,15 @@ export function getWorldPoint(point: Coord, panZoom: PanZoom): Coord {
   return { x: (point.x - offset.x) / scale, y: (point.y - offset.y) / scale };
 }
 
+export function getWorldPointWithoutPanConsideration(
+  point: Coord,
+  panZoom: PanZoom,
+): Coord {
+  const { scale } = panZoom;
+
+  return { x: point.x / scale, y: point.y / scale };
+}
+
 export function convertScreenPointToCartesian(
   canvas: HTMLCanvasElement,
   screenPoint: Coord,

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -78,15 +78,6 @@ export function getWorldPoint(point: Coord, panZoom: PanZoom): Coord {
   return { x: (point.x - offset.x) / scale, y: (point.y - offset.y) / scale };
 }
 
-export function getWorldPointWithoutPanConsideration(
-  point: Coord,
-  panZoom: PanZoom,
-): Coord {
-  const { scale } = panZoom;
-
-  return { x: point.x / scale, y: point.y / scale };
-}
-
 export function convertScreenPointToCartesian(
   canvas: HTMLCanvasElement,
   screenPoint: Coord,


### PR DESCRIPTION
🚀 [Related Issue: #4 ]

### Preview

You can test the new extension algorithm in the PR preview page. Try to make the pixel grid very big and then test out the extension. The extension will not lag at all.

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Improve extension algorithm to let the extension instantly happen 

- **[🎨Component] Replace `extendInteractionGrid`, `shortenInteractionGrid` to `extendInteractionGridBy` and `shortenInteractionGridBy`**
  - Previously, when the pixel canvas was big, the extension lagged a little since the interaction grid extension happened one at a time. Unless a user moves the mouse, the extension did not occur
  - To fix the above problem, I made functions that causes extensions to happen in chunks (`extendInteractionGridBy` & `shortenInteractionGridBy`). Now the extension happens instantly.
  - Also, I have changed the extension to happen based on the mouseOffset(difference between the mouseDownWorldPos and mouseMoveWorldPos) instead of using lastMousePos.


<br/>

## Notes


<br/>

## Next Up?

