### PR TITLE
Feature: align left top position of left top pixel to be (0,0)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,14 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "react-hooks", "unicorn"],
+  "plugins": [
+    "@typescript-eslint",
+    "react-hooks",
+    "unicorn",
+    "import",
+    "unused-imports",
+    "jest"
+  ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
@@ -9,6 +16,12 @@
     "plugin:import/recommended",
     "plugin:import/typescript"
   ],
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true,
+    "jest": true
+  },
   "rules": {
     "@typescript-eslint/no-non-null-assertion": "off",
     "no-case-declarations": "off",
@@ -39,6 +52,17 @@
       "error",
       {
         "cases": { "pascalCase": true, "camelCase": true }
+      }
+    ],
+    "no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
       }
     ]
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -63,8 +63,10 @@
     "eslint": "^8.38.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.2.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unicorn": "^46.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "husky": "^8.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.5.0",
@@ -85,8 +87,5 @@
   "peerDependencies": {
     "react": ">=17.2.0",
     "react-dom": ">=17.2.0"
-  },
-  "dependencies": {
-    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/actions/SelectAreaMoveAction.ts
+++ b/src/actions/SelectAreaMoveAction.ts
@@ -4,7 +4,6 @@ import {
   ColorChangeItem,
   SelectAreaRange,
 } from "../components/Canvas/types";
-import { Coord } from "../utils/types";
 
 export class SelectAreaMoveAction extends Action {
   type = ActionType.SelectAreaMove;

--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -292,8 +292,8 @@ export default class DataLayer extends BaseLayer {
     const squareLength = this.gridSquareLength * this.panZoom.scale;
     // leftTopPoint is a cartesian coordinate
     const leftTopPoint: Coord = {
-      x: -((this.getColumnCount() / 2) * this.gridSquareLength),
-      y: -((this.getRowCount() / 2) * this.gridSquareLength),
+      x: 0,
+      y: 0,
     };
     const ctx = this.ctx;
     ctx.clearRect(0, 0, this.width, this.height);

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent } from "react";
+import React, { KeyboardEvent } from "react";
 
 import BackgroundLayer from "./BackgroundLayer";
 import {
@@ -1666,7 +1666,7 @@ export default class Editor extends EventDispatcher {
           this.interactionLayer.setCapturedBaseExtendingSelectedAreaPixels(
             coloredPixels,
           );
-          const { dataForAction } = this.dataLayer.erasePixels(coloredPixels);
+          this.dataLayer.erasePixels(coloredPixels);
           this.dataLayer.render();
           this.interactionLayer.render();
 

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -155,7 +155,6 @@ export default class Editor extends EventDispatcher {
     );
     this.dataLayer.setCriterionDataForRendering(this.dataLayer.getData());
     this.element = interactionCanvas;
-
     this.initialize();
   }
 
@@ -590,40 +589,25 @@ export default class Editor extends EventDispatcher {
         columnCount * this.gridSquareLength * this.panZoom.scale > this.width;
 
       const minXPosition = isGridColumnsBiggerThanCanvas
-        ? this.width -
-          columnCount * this.gridSquareLength * this.panZoom.scale -
-          ((this.width - columnCount * this.gridSquareLength) *
-            this.panZoom.scale) /
-            2
-        : (-(this.width - columnCount * this.gridSquareLength) / 2) *
-          this.panZoom.scale;
+        ? -(columnCount * this.gridSquareLength * this.panZoom.scale) -
+          (this.width / 2) * this.panZoom.scale
+        : (-this.width / 2) * this.panZoom.scale;
 
       const minYPosition = isGridRowsBiggerThanCanvas
-        ? this.height -
-          rowCount * this.gridSquareLength * this.panZoom.scale -
-          ((this.height - rowCount * this.gridSquareLength) *
-            this.panZoom.scale) /
-            2
-        : (-(this.height - rowCount * this.gridSquareLength) / 2) *
-          this.panZoom.scale;
+        ? -rowCount * this.gridSquareLength * this.panZoom.scale -
+          (this.height / 2) * this.panZoom.scale
+        : (-this.height / 2) * this.panZoom.scale;
 
       const maxXPosition = isGridColumnsBiggerThanCanvas
-        ? (-(this.width - columnCount * this.gridSquareLength) / 2) *
-          this.panZoom.scale
+        ? this.width - (this.width / 2) * this.panZoom.scale
         : this.width -
           columnCount * this.gridSquareLength * this.panZoom.scale -
-          ((this.width - columnCount * this.gridSquareLength) *
-            this.panZoom.scale) /
-            2;
-
+          (this.width / 2) * this.panZoom.scale;
       const maxYPosition = isGridRowsBiggerThanCanvas
-        ? (rowCount * this.gridSquareLength * this.panZoom.scale) / 2 -
-          (this.height / 2) * this.panZoom.scale
+        ? this.height - (this.height / 2) * this.panZoom.scale
         : this.height -
           rowCount * this.gridSquareLength * this.panZoom.scale -
-          ((this.height - rowCount * this.gridSquareLength) *
-            this.panZoom.scale) /
-            2;
+          (this.height / 2) * this.panZoom.scale;
       if (correctedOffset.x < minXPosition) {
         correctedOffset.x = minXPosition;
       }
@@ -638,6 +622,7 @@ export default class Editor extends EventDispatcher {
       }
       this.panZoom.offset = correctedOffset;
     }
+
     // relay updated information to layers
     this.relayPanZoomToOtherLayers();
     // we must render all when panzoom changes!
@@ -876,8 +861,8 @@ export default class Editor extends EventDispatcher {
     const baseColumnCount = getColumnCountFromData(interactionCapturedData);
 
     const panZoomDiff = {
-      x: (this.gridSquareLength / 2) * extendAmount.x * this.panZoom.scale,
-      y: (this.gridSquareLength / 2) * extendAmount.y * this.panZoom.scale,
+      x: this.gridSquareLength * extendAmount.x * this.panZoom.scale,
+      y: this.gridSquareLength * extendAmount.y * this.panZoom.scale,
     };
     if (direction === ButtonDirection.TOP) {
       this.setPanZoom({
@@ -892,7 +877,7 @@ export default class Editor extends EventDispatcher {
       this.setPanZoom({
         offset: {
           x: this.panZoom.offset.x,
-          y: this.panZoom.offset.y + panZoomDiff.y,
+          y: this.panZoom.offset.y,
         },
         baseRowCount,
         baseColumnCount,
@@ -909,7 +894,7 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.RIGHT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x + panZoomDiff.x,
+          x: this.panZoom.offset.x,
           y: this.panZoom.offset.y,
         },
         baseRowCount,
@@ -927,7 +912,7 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.TOPRIGHT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x + panZoomDiff.x,
+          x: this.panZoom.offset.x,
           y: this.panZoom.offset.y - panZoomDiff.y,
         },
         baseRowCount,
@@ -937,7 +922,7 @@ export default class Editor extends EventDispatcher {
       this.setPanZoom({
         offset: {
           x: this.panZoom.offset.x - panZoomDiff.x,
-          y: this.panZoom.offset.y + panZoomDiff.y,
+          y: this.panZoom.offset.y,
         },
         baseRowCount,
         baseColumnCount,
@@ -945,8 +930,8 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.BOTTOMRIGHT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x + panZoomDiff.x,
-          y: this.panZoom.offset.y + panZoomDiff.y,
+          x: this.panZoom.offset.x,
+          y: this.panZoom.offset.y,
         },
         baseRowCount,
         baseColumnCount,
@@ -1016,7 +1001,7 @@ export default class Editor extends EventDispatcher {
       this.setPanZoom({
         offset: {
           x: this.panZoom.offset.x,
-          y: this.panZoom.offset.y + panZoomDiff.y,
+          y: this.panZoom.offset.y + panZoomDiff.y * 2,
         },
         baseColumnCount,
         baseRowCount,
@@ -1025,7 +1010,7 @@ export default class Editor extends EventDispatcher {
       this.setPanZoom({
         offset: {
           x: this.panZoom.offset.x,
-          y: this.panZoom.offset.y - panZoomDiff.y,
+          y: this.panZoom.offset.y,
         },
         baseColumnCount,
         baseRowCount,
@@ -1033,7 +1018,7 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.LEFT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x + panZoomDiff.x,
+          x: this.panZoom.offset.x + panZoomDiff.x * 2,
           y: this.panZoom.offset.y,
         },
         baseColumnCount,
@@ -1042,7 +1027,7 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.RIGHT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x - panZoomDiff.x,
+          x: this.panZoom.offset.x,
           y: this.panZoom.offset.y,
         },
         baseColumnCount,
@@ -1051,8 +1036,8 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.TOPLEFT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x + panZoomDiff.x,
-          y: this.panZoom.offset.y + panZoomDiff.y,
+          x: this.panZoom.offset.x + panZoomDiff.x * 2,
+          y: this.panZoom.offset.y + panZoomDiff.y * 2,
         },
         baseRowCount,
         baseColumnCount,
@@ -1060,8 +1045,8 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.TOPRIGHT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x - panZoomDiff.x,
-          y: this.panZoom.offset.y + panZoomDiff.y,
+          x: this.panZoom.offset.x,
+          y: this.panZoom.offset.y + panZoomDiff.y * 2,
         },
         baseRowCount,
         baseColumnCount,
@@ -1069,8 +1054,8 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.BOTTOMLEFT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x + panZoomDiff.x,
-          y: this.panZoom.offset.y - panZoomDiff.y,
+          x: this.panZoom.offset.x + panZoomDiff.x * 2,
+          y: this.panZoom.offset.y,
         },
         baseRowCount,
         baseColumnCount,
@@ -1078,8 +1063,8 @@ export default class Editor extends EventDispatcher {
     } else if (direction === ButtonDirection.BOTTOMRIGHT) {
       this.setPanZoom({
         offset: {
-          x: this.panZoom.offset.x - panZoomDiff.x,
-          y: this.panZoom.offset.y - panZoomDiff.y,
+          x: this.panZoom.offset.x,
+          y: this.panZoom.offset.y,
         },
         baseRowCount,
         baseColumnCount,
@@ -2463,8 +2448,8 @@ export default class Editor extends EventDispatcher {
       const squareLength = this.gridSquareLength * this.panZoom.scale;
       // leftTopPoint is a cartesian coordinate
       const leftTopPoint: Coord = {
-        x: -((this.dataLayer.getColumnCount() / 2) * this.gridSquareLength),
-        y: -((this.dataLayer.getRowCount() / 2) * this.gridSquareLength),
+        x: 0,
+        y: 0,
       };
       const convertedLetTopScreenPoint = convertCartesianToScreen(
         this.element,

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -155,6 +155,12 @@ export default class Editor extends EventDispatcher {
     );
     this.dataLayer.setCriterionDataForRendering(this.dataLayer.getData());
     this.element = interactionCanvas;
+    this.setPanZoom({
+      offset: {
+        x: this.panZoom.scale * (-initColumnCount / 2) * this.gridSquareLength,
+        y: this.panZoom.scale * (-initRowCount / 2) * this.gridSquareLength,
+      },
+    });
     this.initialize();
   }
 
@@ -1968,8 +1974,29 @@ export default class Editor extends EventDispatcher {
     } else if (e.code === "Backspace" || e.code === "Delete") {
       if (this.interactionLayer.getSelectedArea()) {
         if (this.interactionLayer.getSelectedAreaPixels().length === 0) return;
+        const previousSelectedAreaPixels =
+          this.interactionLayer.getSelectedAreaPixels();
+        if (
+          !previousSelectedAreaPixels ||
+          previousSelectedAreaPixels.length === 0
+        )
+          return;
+
         const { dataForAction } = this.dataLayer.erasePixels(
           this.interactionLayer.getSelectedAreaPixels(),
+        );
+        this.recordAction(
+          new SelectAreaMoveAction(
+            [
+              ...dataForAction.map(pixel => ({
+                ...pixel,
+                color: "",
+              })),
+              ...dataForAction,
+            ],
+            this.interactionLayer.getSelectedArea(),
+            this.interactionLayer.getSelectedArea(),
+          ),
         );
         this.dataLayer.render();
       }

--- a/src/components/Canvas/GridLayer.tsx
+++ b/src/components/Canvas/GridLayer.tsx
@@ -172,30 +172,30 @@ export default class GridLayer extends BaseLayer {
       y: -gridsHeight / 2,
     };
     if (direction === ButtonDirection.LEFT) {
-      buttonPos.x = -gridsWidth / 2 - this.buttonMargin - buttonWidth / 2;
-      buttonPos.y = -gridsHeight / 2;
+      buttonPos.x = -this.buttonMargin - buttonWidth / 2;
+      buttonPos.y = 0;
     } else if (direction === ButtonDirection.RIGHT) {
-      buttonPos.x = gridsWidth / 2 + this.buttonMargin - buttonWidth / 2;
-      buttonPos.y = -gridsHeight / 2;
+      buttonPos.x = gridsWidth + this.buttonMargin - buttonWidth / 2;
+      buttonPos.y = 0;
     } else if (direction === ButtonDirection.TOP) {
-      buttonPos.x = -gridsWidth / 2;
-      buttonPos.y = -gridsHeight / 2 - this.buttonMargin - buttonHeight / 2;
+      buttonPos.x = 0;
+      buttonPos.y = -this.buttonMargin - buttonHeight / 2;
     } else if (direction === ButtonDirection.BOTTOM) {
-      buttonPos.x = -gridsWidth / 2;
-      buttonPos.y = gridsHeight / 2 + this.buttonMargin - buttonHeight / 2;
+      buttonPos.x = 0;
+      buttonPos.y = gridsHeight + this.buttonMargin - buttonHeight / 2;
     } else if (direction === ButtonDirection.TOPLEFT) {
       // FIXME cleanup codes
-      buttonPos.x = -gridsWidth / 2 - this.buttonMargin - buttonWidth / 2;
-      buttonPos.y = -gridsHeight / 2 - this.buttonMargin - buttonHeight / 2;
+      buttonPos.x = -this.buttonMargin - buttonWidth / 2;
+      buttonPos.y = -this.buttonMargin - buttonHeight / 2;
     } else if (direction === ButtonDirection.TOPRIGHT) {
-      buttonPos.x = gridsWidth / 2 + this.buttonMargin - buttonWidth / 2;
-      buttonPos.y = -gridsHeight / 2 - this.buttonMargin - buttonHeight / 2;
+      buttonPos.x = gridsWidth + this.buttonMargin - buttonWidth / 2;
+      buttonPos.y = -this.buttonMargin - buttonHeight / 2;
     } else if (direction === ButtonDirection.BOTTOMLEFT) {
-      buttonPos.x = -gridsWidth / 2 - this.buttonMargin - buttonWidth / 2;
-      buttonPos.y = gridsHeight / 2 + this.buttonMargin - buttonHeight / 2;
+      buttonPos.x = -this.buttonMargin - buttonWidth / 2;
+      buttonPos.y = gridsHeight + this.buttonMargin - buttonHeight / 2;
     } else if (direction === ButtonDirection.BOTTOMRIGHT) {
-      buttonPos.x = gridsWidth / 2 + this.buttonMargin - buttonWidth / 2;
-      buttonPos.y = gridsHeight / 2 + this.buttonMargin - buttonHeight / 2;
+      buttonPos.x = gridsWidth + this.buttonMargin - buttonWidth / 2;
+      buttonPos.y = gridsHeight + this.buttonMargin - buttonHeight / 2;
     } else {
       throw new Error("Invalid button direction");
     }
@@ -510,8 +510,8 @@ export default class GridLayer extends BaseLayer {
     const squareLength = this.gridSquareLength * this.panZoom.scale;
     // leftTopPoint is a cartesian coordinate
     const leftTopPoint: Coord = {
-      x: -((this.columnCount / 2) * this.gridSquareLength),
-      y: -((this.rowCount / 2) * this.gridSquareLength),
+      x: 0,
+      y: 0,
     };
     const convertedScreenPoint = convertCartesianToScreen(
       this.element,

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -1,13 +1,13 @@
 import { BaseLayer } from "./BaseLayer";
 import {
-  DefaultGridSquareLength,
-  UserId,
   ButtonDirection,
-  TemporaryUserId,
+  DefaultGridSquareLength,
   DefaultMaxScale,
   DefaultMinScale,
   InteractionExtensionAllowanceRatio,
   InteractionEdgeTouchingRange,
+  TemporaryUserId,
+  UserId,
 } from "./config";
 import {
   ColorChangeItem,
@@ -34,12 +34,7 @@ import {
   getScreenPoint,
   lerpRanges,
 } from "../../utils/math";
-import {
-  getAreaTopLeftAndBottomRight,
-  getCornerPixelIndices,
-  getOverlappingPixelIndicesForModifiedPixels,
-  getRelativeCornerWordPosOfPixelToOrigin,
-} from "../../utils/position";
+import { getOverlappingPixelIndicesForModifiedPixels } from "../../utils/position";
 
 export default class InteractionLayer extends BaseLayer {
   // We make this a map to allow for multiple users to interact with the canvas
@@ -1433,13 +1428,6 @@ export default class InteractionLayer extends BaseLayer {
   render() {
     const squareLength = this.gridSquareLength * this.panZoom.scale;
     // leftTopPoint is a cartesian coordinate
-    const doesCapturedDataExist = this.capturedData !== null;
-    const rowCount = doesCapturedDataExist
-      ? getRowCountFromData(this.capturedData)
-      : this.dataLayerRowCount;
-    const columnCount = doesCapturedDataExist
-      ? getColumnCountFromData(this.capturedData)
-      : this.dataLayerColumnCount;
     const leftTopPoint: Coord = {
       x: 0,
       y: 0,

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -1441,8 +1441,8 @@ export default class InteractionLayer extends BaseLayer {
       ? getColumnCountFromData(this.capturedData)
       : this.dataLayerColumnCount;
     const leftTopPoint: Coord = {
-      x: -((columnCount / 2) * this.gridSquareLength),
-      y: -((rowCount / 2) * this.gridSquareLength),
+      x: 0,
+      y: 0,
     };
     const convertedLetTopScreenPoint = convertCartesianToScreen(
       this.element,

--- a/src/components/Canvas/_deprecated.ts
+++ b/src/components/Canvas/_deprecated.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { MouseMode, ButtonDirection } from "./config";
+import { ButtonDirection, MouseMode } from "./config";
 import {
   BrushTool,
   CanvasEvents,
@@ -30,7 +30,7 @@ import {
 } from "../../utils/math";
 import Queue from "../../utils/queue";
 import Stack from "../../utils/stack";
-import { addEvent, removeEvent, touchy, TouchyEvent } from "../../utils/touch";
+import { TouchyEvent, addEvent, removeEvent, touchy } from "../../utils/touch";
 import { Indices } from "../../utils/types";
 import { isValidIndicesRange } from "../../utils/validation";
 

--- a/src/components/Canvas/config.ts
+++ b/src/components/Canvas/config.ts
@@ -21,8 +21,8 @@ export enum ButtonDirection {
 }
 
 export const DefaultPixelDataDimensions = {
-  columnCount: 8,
-  rowCount: 6,
+  columnCount: 6,
+  rowCount: 20,
 };
 
 export enum MouseMode {

--- a/src/components/Canvas/config.ts
+++ b/src/components/Canvas/config.ts
@@ -21,8 +21,8 @@ export enum ButtonDirection {
 }
 
 export const DefaultPixelDataDimensions = {
-  columnCount: 6,
-  rowCount: 20,
+  columnCount: 10,
+  rowCount: 10,
 };
 
 export enum MouseMode {

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -1,25 +1,25 @@
 import React, {
   ForwardedRef,
+  forwardRef,
   useCallback,
   useEffect,
   useImperativeHandle,
-  useState,
-  forwardRef,
   useRef,
+  useState,
 } from "react";
 
 import Editor from "./Canvas/Editor";
 import {
-  PixelData,
-  CanvasEvents,
-  CanvasDataChangeHandler,
-  CanvasGridChangeHandler,
-  CanvasStrokeEndHandler,
   BrushTool,
   CanvasBrushChangeHandler,
-  PixelModifyItem,
-  ImageDownloadOptions,
+  CanvasDataChangeHandler,
+  CanvasEvents,
+  CanvasGridChangeHandler,
   CanvasHoverPixelChangeHandler,
+  CanvasStrokeEndHandler,
+  ImageDownloadOptions,
+  PixelData,
+  PixelModifyItem,
 } from "./Canvas/types";
 
 export interface DottingProps {

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -160,8 +160,8 @@ export const getPixelIndexFromMouseCartCoord = (
   currentLeftIndex: number,
 ) => {
   const leftTopPoint: Coord = {
-    x: -((columnCount / 2) * gridSquareLength),
-    y: -((rowCount / 2) * gridSquareLength),
+    x: 0,
+    y: 0,
   };
   if (
     mouseCartCoord.x > leftTopPoint.x &&

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -256,8 +256,8 @@ export const convertWorldPosAreaToPixelGridArea = (
     getAreaTopLeftAndBottomRight(selectingArea);
 
   const pixelGridLeftTopPoint: Coord = {
-    x: -((columnCount / 2) * gridSquareLength),
-    y: -((rowCount / 2) * gridSquareLength),
+    x: 0,
+    y: 0,
   };
   const selectedRegionTopLeft: Coord = {
     x: 0,

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-undef
 export interface MouseEventWithOffsets extends MouseEventInit {
   pageX?: number;
   pageY?: number;

--- a/stories/custom/CustomExample.tsx
+++ b/stories/custom/CustomExample.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect , useRef } from "react";
+import React, {  useRef } from "react";
 
 import { useBrush, useDotting } from "../../src";
 import Dotting, { DottingRef } from "../../src/components/Dotting";

--- a/stories/useBrushComponents/ChangeBrushColor.tsx
+++ b/stories/useBrushComponents/ChangeBrushColor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback , useRef } from "react";
+import React, {  useRef } from "react";
 
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useBrush from "../../src/hooks/useBrush";

--- a/stories/useHandlersComponents/CanvasElementEvents.tsx
+++ b/stories/useHandlersComponents/CanvasElementEvents.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 
-import {
-  CanvasHoverPixelChangeHandler,
-  CanvasStrokeEndHandler,
-  DottingData,
-  PixelModifyItem,
-} from "../../src/components/Canvas/types";
+
+
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useHandlers from "../../src/hooks/useHandlers";
 

--- a/stories/useHandlersComponents/HoverPixelListener.tsx
+++ b/stories/useHandlersComponents/HoverPixelListener.tsx
@@ -1,11 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-import {
-  CanvasHoverPixelChangeHandler,
-  CanvasStrokeEndHandler,
-  DottingData,
-  PixelModifyItem,
-} from "../../src/components/Canvas/types";
+import { CanvasHoverPixelChangeHandler } from "../../src/components/Canvas/types";
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useHandlers from "../../src/hooks/useHandlers";
 

--- a/stories/useHandlersComponents/StrokeListener.tsx
+++ b/stories/useHandlersComponents/StrokeListener.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import {
-  BrushTool,
   CanvasStrokeEndHandler,
   ColorChangeItem,
-  DottingData,
-  PixelModifyItem,
 } from "../../src/components/Canvas/types";
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useHandlers from "../../src/hooks/useHandlers";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,11 +2768,6 @@
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
 
-"@testing-library/user-event@^14.4.3":
-  version "14.4.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
-  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -3215,6 +3210,14 @@
     "@typescript-eslint/types" "5.57.1"
     "@typescript-eslint/visitor-keys" "5.57.1"
 
+"@typescript-eslint/scope-manager@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz#b670006d069c9abe6415c41f754b1b5d949ef2b2"
+  integrity sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==
+  dependencies:
+    "@typescript-eslint/types" "5.61.0"
+    "@typescript-eslint/visitor-keys" "5.61.0"
+
 "@typescript-eslint/type-utils@5.57.1":
   version "5.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.57.1.tgz#235daba621d3f882b8488040597b33777c74bbe9"
@@ -3230,6 +3233,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.57.1.tgz#d9989c7a9025897ea6f0550b7036027f69e8a603"
   integrity sha512-bSs4LOgyV3bJ08F5RDqO2KXqg3WAdwHCu06zOqcQ6vqbTJizyBhuh1o1ImC69X4bV2g1OJxbH71PJqiO7Y1RuA==
 
+"@typescript-eslint/types@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.61.0.tgz#e99ff11b5792d791554abab0f0370936d8ca50c0"
+  integrity sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==
+
 "@typescript-eslint/typescript-estree@5.57.1":
   version "5.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.1.tgz#10d9643e503afc1ca4f5553d9bbe672ea4050b71"
@@ -3237,6 +3245,19 @@
   dependencies:
     "@typescript-eslint/types" "5.57.1"
     "@typescript-eslint/visitor-keys" "5.57.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz#4c7caca84ce95bb41aa585d46a764bcc050b92f3"
+  integrity sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==
+  dependencies:
+    "@typescript-eslint/types" "5.61.0"
+    "@typescript-eslint/visitor-keys" "5.61.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -3257,12 +3278,34 @@
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@^5.10.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.61.0.tgz#5064838a53e91c754fffbddd306adcca3fe0af36"
+  integrity sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.61.0"
+    "@typescript-eslint/types" "5.61.0"
+    "@typescript-eslint/typescript-estree" "5.61.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.57.1":
   version "5.57.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.1.tgz#585e5fa42a9bbcd9065f334fd7c8a4ddfa7d905e"
   integrity sha512-RjQrAniDU0CEk5r7iphkm731zKlFiUjvcBS2yHAg8WWqFMCaCrD0rKEVOMUyMMcbGPZ0bPp56srkGWrgfZqLRA==
   dependencies:
     "@typescript-eslint/types" "5.57.1"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz#c79414fa42158fd23bd2bb70952dc5cdbb298140"
+  integrity sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==
+  dependencies:
+    "@typescript-eslint/types" "5.61.0"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
@@ -6209,6 +6252,13 @@ eslint-plugin-import@^2.27.5:
     semver "^6.3.0"
     tsconfig-paths "^3.14.1"
 
+eslint-plugin-jest@^27.2.2:
+  version "27.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.2.2.tgz#be4ded5f91905d9ec89aa8968d39c71f3b072c0c"
+  integrity sha512-euzbp06F934Z7UDl5ZUaRPLAc9MKjh0rMPERrHT7UhlCEwgb25kBj37TvMgWeHZVkR5I9CayswrpoaqZU1RImw==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.0"
+
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
@@ -6235,6 +6285,18 @@ eslint-plugin-unicorn@^46.0.0:
     safe-regex "^2.1.1"
     semver "^7.3.8"
     strip-indent "^3.0.0"
+
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
🚀 [Related Issue: #47 ]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Change world position alignment

- **[🎨Component] Make left top position of the pixel of `{rowIndex: 0, columnIndex: 0}`  to be world position `{x:0, y:0}`**

  - Previously, the world position of the left top corner of the pixel of `{rowIndex: 0, columnIndex: 0}` was `{x: -(columnCount/2) * this.gridSquareLength, y: -(rowCount/2) * this.gridSquareLength}`. This added confusion to the whole system and necessitated complex calculations.
  - The previous approach is also problematic when we implement multiplayer features since the left top position of the world will constantly change whenever a user changes the grid size of the pixel canvas. This is problematic when one user is selecting an area, and another user suddenly changes the pixel grid size (horizontally or vertically) since the selecting area should be calculated again. (@lerrybe When implementing yorkie into dotting, for the select tool to work properly, the updated version with this PR merged should be applied!)
  - Now the left top position of the pixel of `{rowIndex: 0, columnIndex: 0}` is set to world position `{x:0, y:0}`. This will never change even though the user extends the pixel grid. This means that one can simply calculate the left top position of a pixel of `{rowIndex: a, columnIndex: b}` to have a world position of `{x: a * this.gridSquareLength, y: b *  this.gridSquareLength}`. 


<br/>

## Notes


<br/>

## Next Up?

