### PR TITLE
Feature: Allow Set Data with pixel data array + Allow brush pattern to be set + Trigger event when undo/redo

### DIFF
--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -24,7 +24,7 @@ import {
   getGridIndicesFromData,
   getRowCountFromData,
   getRowKeysFromData,
-  validatePixelArrayData,
+  validateSquareArray,
 } from "../../utils/data";
 import { convertCartesianToScreen, getScreenPoint } from "../../utils/math";
 
@@ -49,7 +49,7 @@ export default class DataLayer extends BaseLayer {
     initData?: Array<Array<PixelData>>;
   }) {
     super({ canvas });
-    if (initData && validatePixelArrayData(initData).isDataValid) {
+    if (initData && validateSquareArray(initData).isDataValid) {
       for (let i = 0; i < initData.length; i++) {
         this.data.set(i, new Map());
         for (let j = 0; j < initData[i].length; j++) {

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -606,7 +606,7 @@ export default class Editor extends EventDispatcher {
       for (let j = 0; j < data[i].length; j++) {
         this.dataLayer
           .getData()
-          .get(topRowIndex + i)!
+          .get(topRowIndex + i)
           .set(leftColumnIndex + j, { color: data[i][j].color });
       }
     }

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -1467,6 +1467,15 @@ export default class Editor extends EventDispatcher {
         );
         break;
     }
+    const updatedData = this.dataLayer.getCopiedData();
+    this.emitGridChangeEvent({
+      dimensions: {
+        rowCount: getRowCountFromData(updatedData),
+        columnCount: getColumnCountFromData(updatedData),
+      },
+      indices: getGridIndicesFromData(updatedData),
+    });
+    this.emitDataChangeEvent({ data: updatedData });
   }
 
   recordAction(action: Action) {

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -14,6 +14,7 @@ import DataLayer from "./DataLayer";
 import GridLayer from "./GridLayer";
 import InteractionLayer from "./InteractionLayer";
 import {
+  BRUSH_PATTERN_ELEMENT,
   BrushTool,
   CanvasBrushChangeParams,
   CanvasDataChangeParams,
@@ -231,7 +232,7 @@ export default class Editor extends EventDispatcher {
     this.emit(CanvasEvents.BRUSH_CHANGE, params);
   }
 
-  setBrushPattern(pattern: Array<Array<1 | 0>>) {
+  setBrushPattern(pattern: Array<Array<BRUSH_PATTERN_ELEMENT>>) {
     this.interactionLayer.setBrushPattern(pattern);
     this.emitBrushChangeEvent({
       brushColor: this.brushColor,
@@ -1228,7 +1229,7 @@ export default class Editor extends EventDispatcher {
   private drawPixelInInteractionLayer(
     rowIndex: number,
     columnIndex: number,
-    brushPattern: Array<Array<1 | 0>>,
+    brushPattern: Array<Array<BRUSH_PATTERN_ELEMENT>>,
   ) {
     const interactionLayer = this.interactionLayer;
     const data = this.dataLayer.getData();

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -572,7 +572,7 @@ export default class Editor extends EventDispatcher {
 
   /**
    * @summary Sets the data of the pixel array (use with caution, since data will be overwritten!)
-   * @param data Array of PixelData (It must be a rectangular array, i.e. all rows must have the same length)
+   * @param data Array of PixelModifyItem (It must be a rectangular array, i.e. all rows must have the same length)
    */
   setData(data: Array<Array<PixelModifyItem>>) {
     const isDataValid = validatePixelArrayData(data);
@@ -605,10 +605,6 @@ export default class Editor extends EventDispatcher {
     this.gridLayer.setRowCount(rowCount);
     this.gridLayer.setColumnCount(columnCount);
 
-    this.interactionLayer.setCriterionDataForRendering(
-      this.dataLayer.getData(),
-    );
-    this.interactionLayer.resetCapturedData();
     this.interactionLayer.setDataLayerRowCount(rowCount);
     this.interactionLayer.setDataLayerColumnCount(columnCount);
     this.emitDataChangeEvent({ data: this.dataLayer.getCopiedData() });
@@ -616,7 +612,18 @@ export default class Editor extends EventDispatcher {
       dimensions: this.dataLayer.getDimensions(),
       indices: this.dataLayer.getGridIndices(),
     });
+    this.interactionLayer.setCriterionDataForRendering(
+      this.dataLayer.getData(),
+    );
+    this.dataLayer.setCriterionDataForRendering(this.dataLayer.getData());
+    this.interactionLayer.resetCapturedData();
 
+    this.setPanZoom({
+      offset: {
+        x: -this.panZoom.scale * (columnCount / 2) * this.gridSquareLength,
+        y: -this.panZoom.scale * (rowCount / 2) * this.gridSquareLength,
+      },
+    });
     this.renderAll();
   }
 

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -44,7 +44,7 @@ import {
   getInBetweenPixelIndicesfromCoords,
   getRowCountFromData,
   getRowKeysFromData,
-  validatePixelArrayData,
+  validateSquareArray,
 } from "../../utils/data";
 import EventDispatcher from "../../utils/eventDispatcher";
 import { generatePixelId } from "../../utils/identifier";
@@ -591,7 +591,7 @@ export default class Editor extends EventDispatcher {
    * @param data Array of PixelModifyItem (It must be a rectangular array, i.e. all rows must have the same length)
    */
   setData(data: Array<Array<PixelModifyItem>>) {
-    const isDataValid = validatePixelArrayData(data);
+    const { isDataValid, rowCount, columnCount } = validateSquareArray(data);
     if (!isDataValid) {
       throw new Error(`Data is not valid`);
     }
@@ -600,22 +600,15 @@ export default class Editor extends EventDispatcher {
 
     // reset data
     this.dataLayer.setData(new Map());
-    let rowIndex = 0;
-    let columnIndex = 0;
     for (let i = 0; i < data.length; i++) {
-      rowIndex = topRowIndex + i;
-      this.dataLayer.getData().set(rowIndex, new Map());
+      this.dataLayer.getData().set(topRowIndex + i, new Map());
       for (let j = 0; j < data[i].length; j++) {
-        columnIndex = leftColumnIndex + j;
         this.dataLayer
           .getData()
-          .get(rowIndex)!
-          .set(columnIndex, { color: data[i][j].color });
+          .get(topRowIndex + i)!
+          .set(leftColumnIndex + j, { color: data[i][j].color });
       }
-      columnIndex = 0;
     }
-    const rowCount = this.dataLayer.getRowCount();
-    const columnCount = this.dataLayer.getColumnCount();
 
     this.gridLayer.setCriterionDataForRendering(this.dataLayer.getData());
     this.gridLayer.setRowCount(rowCount);

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -207,6 +207,7 @@ export default class Editor extends EventDispatcher {
     this.emitBrushChangeEvent({
       brushColor: this.brushColor,
       brushTool: this.brushTool,
+      brushPattern: this.interactionLayer.getBrushPattern(),
     });
   }
 
@@ -232,6 +233,11 @@ export default class Editor extends EventDispatcher {
 
   setBrushPattern(pattern: Array<Array<1 | 0>>) {
     this.interactionLayer.setBrushPattern(pattern);
+    this.emitBrushChangeEvent({
+      brushColor: this.brushColor,
+      brushTool: this.brushTool,
+      brushPattern: this.interactionLayer.getBrushPattern(),
+    });
   }
 
   // background related functions ⬇
@@ -307,6 +313,7 @@ export default class Editor extends EventDispatcher {
     this.emitBrushChangeEvent({
       brushColor: this.brushColor,
       brushTool: this.brushTool,
+      brushPattern: this.interactionLayer.getBrushPattern(),
     });
   }
 
@@ -319,6 +326,7 @@ export default class Editor extends EventDispatcher {
     this.emitBrushChangeEvent({
       brushColor: this.brushColor,
       brushTool: this.brushTool,
+      brushPattern: this.interactionLayer.getBrushPattern(),
     });
   }
 
@@ -334,6 +342,10 @@ export default class Editor extends EventDispatcher {
         this.renderDataLayer();
       }
     }
+  }
+
+  getBrushPattern() {
+    return this.interactionLayer.getBrushPattern();
   }
 
   getColumnCount() {

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -10,6 +10,7 @@ import {
   UserId,
 } from "./config";
 import {
+  BRUSH_PATTERN_ELEMENT,
   ColorChangeItem,
   Coord,
   DottingData,
@@ -59,7 +60,9 @@ export default class InteractionLayer extends BaseLayer {
     "startPixelIndex" | "endPixelIndex"
   > | null = null;
 
-  private brushPattern: Array<Array<1 | 0>> = [[1]];
+  private brushPattern: Array<Array<BRUSH_PATTERN_ELEMENT>> = [
+    [BRUSH_PATTERN_ELEMENT.FILL],
+  ];
 
   private selectedArea: SelectAreaRange | null = null;
 
@@ -127,7 +130,7 @@ export default class InteractionLayer extends BaseLayer {
     return this.brushPattern;
   }
 
-  setBrushPattern(pattern: Array<Array<1 | 0>>) {
+  setBrushPattern(pattern: Array<Array<BRUSH_PATTERN_ELEMENT>>) {
     this.brushPattern = pattern;
   }
 

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -59,11 +59,7 @@ export default class InteractionLayer extends BaseLayer {
     "startPixelIndex" | "endPixelIndex"
   > | null = null;
 
-  private brushPattern: Array<Array<1 | 0>> = [
-    [0, 1, 0],
-    [1, 1, 1],
-    [0, 1, 0],
-  ];
+  private brushPattern: Array<Array<1 | 0>> = [[1]];
 
   private selectedArea: SelectAreaRange | null = null;
 

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -59,6 +59,12 @@ export default class InteractionLayer extends BaseLayer {
     "startPixelIndex" | "endPixelIndex"
   > | null = null;
 
+  private brushPattern: Array<Array<1 | 0>> = [
+    [0, 1, 0],
+    [1, 1, 1],
+    [0, 1, 0],
+  ];
+
   private selectedArea: SelectAreaRange | null = null;
 
   private directionToExtendSelectedArea: ButtonDirection | null = null;
@@ -119,6 +125,14 @@ export default class InteractionLayer extends BaseLayer {
 
   getCapturedDataOriginalIndices() {
     return this.capturedDataOriginalIndices;
+  }
+
+  getBrushPattern() {
+    return this.brushPattern;
+  }
+
+  setBrushPattern(pattern: Array<Array<1 | 0>>) {
+    this.brushPattern = pattern;
   }
 
   setDataLayerColumnCount(columnCount: number) {
@@ -1399,21 +1413,53 @@ export default class InteractionLayer extends BaseLayer {
     if (relativeRowIndex === undefined || relativeColumnIndex === undefined) {
       return;
     }
+    const brushPatternWidth = this.brushPattern.length;
+    const brushPatternHeight = this.brushPattern[0].length;
+    const brushPatternCenterRowIndex = Math.floor(brushPatternHeight / 2);
+    const brushPatternCenterColumnIndex = Math.floor(brushPatternWidth / 2);
     ctx.save();
     ctx.globalAlpha = 0.5;
-    ctx.clearRect(
-      relativeColumnIndex * squareLength + correctedLeftTopScreenPoint.x,
-      relativeRowIndex * squareLength + correctedLeftTopScreenPoint.y,
-      squareLength,
-      squareLength,
-    );
-    ctx.fillStyle = this.hoveredPixel.color;
-    ctx.fillRect(
-      relativeColumnIndex * squareLength + correctedLeftTopScreenPoint.x,
-      relativeRowIndex * squareLength + correctedLeftTopScreenPoint.y,
-      squareLength,
-      squareLength,
-    );
+    for (let i = 0; i < brushPatternHeight; i++) {
+      for (let j = 0; j < brushPatternWidth; j++) {
+        const brushPatternItem = this.brushPattern[i][j];
+        if (brushPatternItem === 0) {
+          continue;
+        }
+        const relativeRowIndex = this.rowKeyOrderMap.get(
+          rowIndex + i - brushPatternCenterRowIndex,
+        );
+        const relativeColumnIndex = this.columnKeyOrderMap.get(
+          columnIndex + j - brushPatternCenterColumnIndex,
+        );
+        if (
+          relativeRowIndex === undefined ||
+          relativeColumnIndex === undefined
+        ) {
+          continue;
+        }
+        ctx.fillStyle = this.hoveredPixel.color;
+        ctx.fillRect(
+          relativeColumnIndex * squareLength + correctedLeftTopScreenPoint.x,
+          relativeRowIndex * squareLength + correctedLeftTopScreenPoint.y,
+          squareLength,
+          squareLength,
+        );
+      }
+    }
+
+    // ctx.clearRect(
+    //   relativeColumnIndex * squareLength + correctedLeftTopScreenPoint.x,
+    //   relativeRowIndex * squareLength + correctedLeftTopScreenPoint.y,
+    //   squareLength,
+    //   squareLength,
+    // );
+    // ctx.fillStyle = this.hoveredPixel.color;
+    // ctx.fillRect(
+    //   relativeColumnIndex * squareLength + correctedLeftTopScreenPoint.x,
+    //   relativeRowIndex * squareLength + correctedLeftTopScreenPoint.y,
+    //   squareLength,
+    //   squareLength,
+    // );
     ctx.restore();
   }
 

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -81,7 +81,7 @@ export type CanvasStrokeEndHandler = (params: CanvasStrokeEndParams) => void;
 export type CanvasBrushChangeParams = {
   brushColor: string;
   brushTool: BrushTool;
-  brushPattern: Array<Array<1 | 0>>;
+  brushPattern: Array<Array<BRUSH_PATTERN_ELEMENT>>;
 };
 
 export type CanvasBrushChangeHandler = (
@@ -112,3 +112,8 @@ export type SelectAreaRange = {
   startPixelIndex: Omit<PixelModifyItem, "color">;
   endPixelIndex: Omit<PixelModifyItem, "color">;
 };
+
+export enum BRUSH_PATTERN_ELEMENT {
+  FILL = 1,
+  EMPTY = 0,
+}

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -81,6 +81,7 @@ export type CanvasStrokeEndHandler = (params: CanvasStrokeEndParams) => void;
 export type CanvasBrushChangeParams = {
   brushColor: string;
   brushTool: BrushTool;
+  brushPattern: Array<Array<1 | 0>>;
 };
 
 export type CanvasBrushChangeHandler = (

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -52,6 +52,7 @@ export interface DottingRef {
   setIndicatorPixels: (data: Array<PixelModifyItem>) => void;
   undo: () => void;
   redo: () => void;
+  setData: (data: Array<Array<PixelModifyItem>>) => void;
   // for useBrush
   changeBrushColor: (color: string) => void;
   changeBrushTool: (tool: BrushTool) => void;
@@ -533,6 +534,13 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     editor?.redo();
   }, [editor]);
 
+  const setData = useCallback(
+    (data: Array<Array<PixelModifyItem>>) => {
+      editor?.setData(data);
+    },
+    [editor],
+  );
+
   // useImperativeHandle makes the ref used in the place that uses the FC component
   // We will make our DotterRef manipulatable with the following functions
   useImperativeHandle(
@@ -546,6 +554,7 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       setIndicatorPixels,
       undo,
       redo,
+      setData,
       // for useBrush
       changeBrushColor,
       changeBrushTool,
@@ -573,6 +582,7 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       setIndicatorPixels,
       undo,
       redo,
+      setData,
       // for useBrush
       changeBrushColor,
       changeBrushTool,

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -56,6 +56,7 @@ export interface DottingRef {
   // for useBrush
   changeBrushColor: (color: string) => void;
   changeBrushTool: (tool: BrushTool) => void;
+  changeBrushPattern: (pattern: Array<Array<1 | 0>>) => void;
   // for useHandler
   addDataChangeListener: (listener: CanvasDataChangeHandler) => void;
   removeDataChangeListener: (listener: CanvasDataChangeHandler) => void;
@@ -519,6 +520,13 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     [editor],
   );
 
+  const changeBrushPattern = useCallback(
+    (pattern: Array<Array<1 | 0>>) => {
+      editor?.setBrushPattern(pattern);
+    },
+    [editor],
+  );
+
   const changeBrushTool = useCallback(
     (brushTool: BrushTool) => {
       editor?.setBrushTool(brushTool);
@@ -558,6 +566,7 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       // for useBrush
       changeBrushColor,
       changeBrushTool,
+      changeBrushPattern,
       // for useHandler
       addDataChangeListener,
       removeDataChangeListener,
@@ -586,6 +595,7 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       // for useBrush
       changeBrushColor,
       changeBrushTool,
+      changeBrushPattern,
       // for useHandler
       addDataChangeListener,
       removeDataChangeListener,

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -10,6 +10,7 @@ import React, {
 
 import Editor from "./Canvas/Editor";
 import {
+  BRUSH_PATTERN_ELEMENT,
   BrushTool,
   CanvasBrushChangeHandler,
   CanvasDataChangeHandler,
@@ -56,7 +57,7 @@ export interface DottingRef {
   // for useBrush
   changeBrushColor: (color: string) => void;
   changeBrushTool: (tool: BrushTool) => void;
-  changeBrushPattern: (pattern: Array<Array<1 | 0>>) => void;
+  changeBrushPattern: (pattern: Array<Array<BRUSH_PATTERN_ELEMENT>>) => void;
   // for useHandler
   addDataChangeListener: (listener: CanvasDataChangeHandler) => void;
   removeDataChangeListener: (listener: CanvasDataChangeHandler) => void;
@@ -521,7 +522,7 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
   );
 
   const changeBrushPattern = useCallback(
-    (pattern: Array<Array<1 | 0>>) => {
+    (pattern: Array<Array<BRUSH_PATTERN_ELEMENT>>) => {
       editor?.setBrushPattern(pattern);
     },
     [editor],

--- a/src/hooks/useBrush.ts
+++ b/src/hooks/useBrush.ts
@@ -7,13 +7,19 @@ import { DottingRef } from "../components/Dotting";
 const useBrush = (ref: MutableRefObject<DottingRef | null>) => {
   const [brushTool, setBrushTool] = useState<BrushTool>(BrushTool.DOT);
   const [brushColor, setBrushColor] = useState<string>("");
+  const [brushPattern, setBrushPattern] = useState<Array<Array<1 | 0>>>([[1]]);
   const { addBrushChangeListener, removeBrushChangeListener } =
     useHandlers(ref);
 
   useEffect(() => {
-    const listener = ({ brushColor, brushTool }: CanvasBrushChangeParams) => {
+    const listener = ({
+      brushColor,
+      brushTool,
+      brushPattern,
+    }: CanvasBrushChangeParams) => {
       setBrushTool(brushTool);
       setBrushColor(brushColor);
+      setBrushPattern(brushPattern);
     };
     addBrushChangeListener(listener);
     return () => {
@@ -23,6 +29,13 @@ const useBrush = (ref: MutableRefObject<DottingRef | null>) => {
   const changeBrushColor = useCallback(
     (brushColor: string) => {
       ref.current?.changeBrushColor(brushColor);
+    },
+    [ref],
+  );
+
+  const changeBrushPattern = useCallback(
+    (brushPattern: Array<Array<1 | 0>>) => {
+      ref.current?.changeBrushPattern(brushPattern);
     },
     [ref],
   );
@@ -37,8 +50,10 @@ const useBrush = (ref: MutableRefObject<DottingRef | null>) => {
   return {
     changeBrushColor,
     changeBrushTool,
+    changeBrushPattern,
     brushTool,
     brushColor,
+    brushPattern,
   };
 };
 

--- a/src/hooks/useBrush.ts
+++ b/src/hooks/useBrush.ts
@@ -1,13 +1,19 @@
 import { MutableRefObject, useCallback, useEffect, useState } from "react";
 
 import useHandlers from "./useHandlers";
-import { BrushTool, CanvasBrushChangeParams } from "../components/Canvas/types";
+import {
+  BRUSH_PATTERN_ELEMENT,
+  BrushTool,
+  CanvasBrushChangeParams,
+} from "../components/Canvas/types";
 import { DottingRef } from "../components/Dotting";
 
 const useBrush = (ref: MutableRefObject<DottingRef | null>) => {
   const [brushTool, setBrushTool] = useState<BrushTool>(BrushTool.DOT);
   const [brushColor, setBrushColor] = useState<string>("");
-  const [brushPattern, setBrushPattern] = useState<Array<Array<1 | 0>>>([[1]]);
+  const [brushPattern, setBrushPattern] = useState<
+    Array<Array<BRUSH_PATTERN_ELEMENT>>
+  >([[BRUSH_PATTERN_ELEMENT.FILL]]);
   const { addBrushChangeListener, removeBrushChangeListener } =
     useHandlers(ref);
 
@@ -34,7 +40,7 @@ const useBrush = (ref: MutableRefObject<DottingRef | null>) => {
   );
 
   const changeBrushPattern = useCallback(
-    (brushPattern: Array<Array<1 | 0>>) => {
+    (brushPattern: Array<Array<BRUSH_PATTERN_ELEMENT>>) => {
       ref.current?.changeBrushPattern(brushPattern);
     },
     [ref],

--- a/src/hooks/useDotting.ts
+++ b/src/hooks/useDotting.ts
@@ -47,6 +47,13 @@ const useDotting = (ref: MutableRefObject<DottingRef | null>) => {
     ref.current?.redo();
   }, [ref]);
 
+  const setData = useCallback(
+    (data: Array<Array<PixelModifyItem>>) => {
+      ref.current?.setData(data);
+    },
+    [ref],
+  );
+
   return {
     clear,
     colorPixels,
@@ -55,6 +62,7 @@ const useDotting = (ref: MutableRefObject<DottingRef | null>) => {
     setIndicatorPixels,
     undo,
     redo,
+    setData,
   };
 };
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -3,7 +3,6 @@ import { getPixelIndexFromMouseCartCoord } from "./position";
 import {
   DottingData,
   GridIndices,
-  PixelData,
   PixelModifyItem,
   Coord,
 } from "../components/Canvas/types";
@@ -111,7 +110,7 @@ export const addColumnToData = (data: DottingData, columnIndex: number) => {
   });
 };
 
-export const validatePixelArrayData = (data: Array<Array<PixelData>>) => {
+export const validateSquareArray = (data: Array<Array<unknown>>) => {
   const dataRowCount = data.length;
   let columnCount = 0;
   const rowCount = dataRowCount;

--- a/stories/useBrush.stories.mdx
+++ b/stories/useBrush.stories.mdx
@@ -245,10 +245,16 @@ With `useBrush`, you can change the brush color and mode.
       </td>
     </tr>
     <tr>
-      <td>`changeBrushPattern(brushPattern: Array<Array<1 | 0>>)`</td>
+      <td>`changeBrushPattern(brushPattern: Array<Array<BRUSH_PATTERN_ELEMENT>>)`</td>
       <td>Allows you to change the brush pattern (the parameter should be a square array)</td>
       <td>
-        `Array<Array<1 | 0>>`
+        `Array<Array<BRUSH_PATTERN_ELEMENT>>`
+        ```ts
+        export enum BRUSH_PATTERN_ELEMENT {
+          EMPTY = 0,
+          FILLED = 1,
+        }
+        ```
       </td>
     </tr>
     <tr>
@@ -265,7 +271,7 @@ With `useBrush`, you can change the brush color and mode.
     </tr>
      <tr>
       <td>`brushPattern`</td>
-      <td>Allows you to know the current brush pattern. Variable type is `Array<Array<1 | 0>>`</td>
+      <td>Allows you to know the current brush pattern. Variable type is `Array<Array<BRUSH_PATTERN_ELEMENT>>`</td>
       <td>
       </td>
     </tr>
@@ -286,7 +292,7 @@ With `changeBrushTool` method, you can change the brush tool.
 
 <ChangeBrushTool />
 
-#### 3. Change Brush Pattern Example `changeBrushPattern(brushPattern: Array<Array<1 | 0>>)`
+#### 3. Change Brush Pattern Example `changeBrushPattern(brushPattern: Array<Array<BRUSH_PATTERN_ELEMENT>>)`
 
 With `changeBrushPattern` method, you can change the brush tool.
 

--- a/stories/useBrush.stories.mdx
+++ b/stories/useBrush.stories.mdx
@@ -8,7 +8,11 @@ import Plugin from "./assets/plugin.svg";
 import Repo from "./assets/repo.svg";
 import StackAlt from "./assets/stackalt.svg";
 import Dotting from "../src/components/Dotting";
-import { ChangeBrushColor, ChangeBrushTool } from "./useBrushComponents";
+import {
+  ChangeBrushColor,
+  ChangeBrushTool,
+  ChangeBrushPattern,
+} from "./useBrushComponents";
 
 <Meta title="Hooks/useBrush" />
 
@@ -241,6 +245,13 @@ With `useBrush`, you can change the brush color and mode.
       </td>
     </tr>
     <tr>
+      <td>`changeBrushPattern(brushPattern: Array<Array<1 | 0>>)`</td>
+      <td>Allows you to change the brush pattern (the parameter should be a square array)</td>
+      <td>
+        `Array<Array<1 | 0>>`
+      </td>
+    </tr>
+    <tr>
       <td>`brushTool`</td>
       <td>Allows you to know the current brush mode. Variable type is `BrushTool`</td>
       <td>
@@ -249,6 +260,12 @@ With `useBrush`, you can change the brush color and mode.
     <tr>
       <td>`brushColor`</td>
       <td>Allows you to know the current brush color. Variable type is `string`</td>
+      <td>
+      </td>
+    </tr>
+     <tr>
+      <td>`brushPattern`</td>
+      <td>Allows you to know the current brush pattern. Variable type is `Array<Array<1 | 0>>`</td>
       <td>
       </td>
     </tr>
@@ -268,6 +285,12 @@ With `changeBrushColor` method, you can change the color of the brush.
 With `changeBrushTool` method, you can change the brush tool.
 
 <ChangeBrushTool />
+
+#### 3. Change Brush Pattern Example `changeBrushPattern(brushPattern: Array<Array<1 | 0>>)`
+
+With `changeBrushPattern` method, you can change the brush tool.
+
+<ChangeBrushPattern />
 
 <div className="subheading">Example Source Codes</div>
 

--- a/stories/useBrushComponents/ChangeBrushPattern.tsx
+++ b/stories/useBrushComponents/ChangeBrushPattern.tsx
@@ -74,7 +74,7 @@ const ChangeBrushPattern = () => {
         }}
       >
         <span>Brush Mode</span>
-        <div style={{ display: "flex", alignItems: "center" }}>
+        <div style={{ display: "flex", alignItems: "center", marginTop: 10 }}>
           {patterns.map((pattern, index) => {
             return (
               <div

--- a/stories/useBrushComponents/ChangeBrushPattern.tsx
+++ b/stories/useBrushComponents/ChangeBrushPattern.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
 
+import { BRUSH_PATTERN_ELEMENT } from "../../src";
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useBrush from "../../src/hooks/useBrush";
 
@@ -14,8 +15,8 @@ const ChangeBrushPattern = () => {
     [],
   );
   const [selectedPatternIndex, setSelectedPatternIndex] = useState<number>(0);
-  const patterns: Array<Array<Array<1 | 0>>> = useMemo<
-    Array<Array<Array<1 | 0>>>
+  const patterns: Array<Array<Array<BRUSH_PATTERN_ELEMENT>>> = useMemo<
+    Array<Array<Array<BRUSH_PATTERN_ELEMENT>>>
   >(() => {
     return [
       [[1]],

--- a/stories/useBrushComponents/ChangeBrushPattern.tsx
+++ b/stories/useBrushComponents/ChangeBrushPattern.tsx
@@ -1,0 +1,152 @@
+import React, { useCallback, useMemo, useRef, useState } from "react";
+
+import Dotting, { DottingRef } from "../../src/components/Dotting";
+import useBrush from "../../src/hooks/useBrush";
+
+const ChangeBrushPattern = () => {
+  const ref = useRef<DottingRef>(null);
+  const { changeBrushColor, changeBrushPattern, brushColor } = useBrush(ref);
+
+  const handleColorChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      changeBrushColor.bind(null, e.target.value)();
+    },
+    [],
+  );
+  const [selectedPatternIndex, setSelectedPatternIndex] = useState<number>(0);
+  const patterns: Array<Array<Array<1 | 0>>> = useMemo<
+    Array<Array<Array<1 | 0>>>
+  >(() => {
+    return [
+      [[1]],
+      [
+        [0, 1, 0],
+        [1, 1, 1],
+        [0, 1, 0],
+      ],
+      [
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1],
+      ],
+      [
+        [0, 0, 1, 0, 0],
+        [0, 1, 1, 1, 0],
+        [1, 1, 1, 1, 1],
+        [0, 1, 1, 1, 0],
+        [0, 0, 1, 0, 0],
+      ],
+      [
+        [0, 1, 1, 1, 0],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [0, 1, 1, 1, 0],
+      ],
+      [
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+      ],
+    ];
+  }, []);
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        fontFamily: `'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif`,
+      }}
+    >
+      <Dotting ref={ref} width={"100%"} height={300} />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          marginTop: 10,
+          marginBottom: 3,
+          fontSize: 13,
+        }}
+      >
+        <span>Brush Mode</span>
+        <div style={{ display: "flex", alignItems: "center" }}>
+          {patterns.map((pattern, index) => {
+            return (
+              <div
+                style={{
+                  display: "flex",
+                  backgroundColor: selectedPatternIndex === index ? "grey" : "",
+                  marginLeft: 5,
+                  marginRight: 5,
+                  width: 80,
+                  height: 80,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+                onClick={() => {
+                  setSelectedPatternIndex(index);
+                  changeBrushPattern(pattern);
+                }}
+              >
+                {pattern.map(row => {
+                  return (
+                    <div
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                      }}
+                    >
+                      {row.map(cell => {
+                        return (
+                          <div
+                            style={{
+                              width: 10,
+                              height: 10,
+                              backgroundColor: cell === 1 ? "black" : "",
+                              margin: 1,
+                            }}
+                          ></div>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          marginTop: 10,
+          marginBottom: 3,
+        }}
+      >
+        <span style={{ fontSize: 13 }}>Brush Color</span>
+        <div
+          style={{
+            borderRadius: "50%",
+            width: 20,
+            height: 20,
+            marginLeft: 15,
+            marginRight: 15,
+            backgroundColor: brushColor,
+          }}
+        ></div>
+        <input type="color" value={brushColor} onChange={handleColorChange} />
+        {/* <button onClick={undo}>undo</button> */}
+        {/* <button onClick={redo}>redo</button> */}
+      </div>
+      <div></div>
+    </div>
+  );
+};
+
+export default ChangeBrushPattern;

--- a/stories/useBrushComponents/ChangeBrushTool.tsx
+++ b/stories/useBrushComponents/ChangeBrushTool.tsx
@@ -26,6 +26,7 @@ const ChangeBrushTool = () => {
         flexDirection: "column",
         alignItems: "center",
         fontFamily: `'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif`,
+        marginBottom: 50,
       }}
     >
       <Dotting ref={ref} width={"100%"} height={300} />

--- a/stories/useBrushComponents/index.ts
+++ b/stories/useBrushComponents/index.ts
@@ -1,4 +1,5 @@
 import ChangeBrushColor from "./ChangeBrushColor";
+import ChangeBrushPattern from "./ChangeBrushPattern";
 import ChangeBrushTool from "./ChangeBrushTool";
 
-export { ChangeBrushColor, ChangeBrushTool };
+export { ChangeBrushColor, ChangeBrushTool, ChangeBrushPattern };

--- a/stories/useDotting.stories.mdx
+++ b/stories/useDotting.stories.mdx
@@ -14,6 +14,7 @@ import {
   DownloadImage,
   SetIndicatorPixels,
   UndoRedo,
+  SetData,
 } from "./useDottingComponents";
 
 <Meta title="Hooks/useDotting" />
@@ -277,6 +278,23 @@ With `useDotting`, you can manipulate the grids.
       <td>`Array<PixelModifyItem>`</td>
     </tr>
     <tr>
+      <td>`setData(data: Array<Array<PixelModifyItem>>)`</td>
+      <td>
+        Allows you to set the data of the pixel canvas. (The 2d array should be a square array)
+      </td>
+      <td>
+        `Array<PixelModifyItem>`
+        `PixelModifyItem` is defined as follows:
+        ```ts
+        export interface PixelModifyItem {
+          rowIndex: number;
+          columnIndex: number;
+          color: string;
+        }
+        ```
+      </td>
+    </tr>
+    <tr>
       <td>`undo()`</td>
       <td>
         Allows you to undo the last action
@@ -350,6 +368,12 @@ The data type of the `initIndicatorData` is the `Array<PixelModifyItem>`.
 With `undo` and `redo` methods, you can undo and redo the last action.
 
 <UndoRedo />
+
+#### 6. SetData Example `setData(data: Array<Array<PixelModifyItem>>)`
+
+With `setData`, you can set the data of the pixel canvas. (The 2d array should be a square array)
+
+<SetData />
 
 <div className="subheading">Example Source Codes</div>
 

--- a/stories/useDottingComponents/SetData.tsx
+++ b/stories/useDottingComponents/SetData.tsx
@@ -1,0 +1,150 @@
+import React, { useRef } from "react";
+
+import Dotting, { DottingRef } from "../../src/components/Dotting";
+import useDotting from "../../src/hooks/useDotting";
+
+const SetData = () => {
+  const ref = useRef<DottingRef>(null);
+  const { colorPixels, erasePixels, setData } = useDotting(ref);
+  const [rowIndex, setRowIndex] = React.useState(0);
+  const [columnIndex, setColumnIndex] = React.useState(0);
+  const [rowIndex2, setRowIndex2] = React.useState(0);
+  const [columnIndex2, setColumnIndex2] = React.useState(0);
+  return (
+    <div
+      style={{
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        fontFamily: `'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif`,
+      }}
+    >
+      <Dotting ref={ref} width={"100%"} height={300} />
+      <div>
+        <div
+          style={{
+            padding: "20px 0",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            gap: 5,
+          }}
+        >
+          <button
+            style={{
+              padding: "5px 10px",
+              background: "none",
+            }}
+            onClick={() => {
+              setData([
+                [
+                  { rowIndex: 0, columnIndex: 0, color: "" },
+                  { rowIndex: 0, columnIndex: 1, color: "" },
+                  { rowIndex: 0, columnIndex: 2, color: "" },
+                ],
+                [
+                  { rowIndex: 1, columnIndex: 0, color: "" },
+                  { rowIndex: 1, columnIndex: 1, color: "" },
+                  { rowIndex: 1, columnIndex: 2, color: "" },
+                ],
+                [
+                  { rowIndex: 2, columnIndex: 0, color: "" },
+                  { rowIndex: 2, columnIndex: 1, color: "" },
+                  { rowIndex: 2, columnIndex: 2, color: "" },
+                ],
+              ]);
+            }}
+          >
+            Set Data to 3 X 3
+          </button>
+          <button
+            style={{
+              padding: "5px 10px",
+              background: "none",
+            }}
+            onClick={() => {
+              setData([
+                [
+                  { rowIndex: 0, columnIndex: 0, color: "" },
+                  { rowIndex: 0, columnIndex: 1, color: "" },
+                  { rowIndex: 0, columnIndex: 2, color: "" },
+                  { rowIndex: 0, columnIndex: 3, color: "" },
+                ],
+                [
+                  { rowIndex: 1, columnIndex: 0, color: "" },
+                  { rowIndex: 1, columnIndex: 1, color: "" },
+                  { rowIndex: 1, columnIndex: 2, color: "" },
+                  { rowIndex: 1, columnIndex: 3, color: "" },
+                ],
+                [
+                  { rowIndex: 2, columnIndex: 0, color: "" },
+                  { rowIndex: 2, columnIndex: 1, color: "" },
+                  { rowIndex: 2, columnIndex: 2, color: "" },
+                  { rowIndex: 2, columnIndex: 3, color: "" },
+                ],
+                [
+                  { rowIndex: 3, columnIndex: 0, color: "" },
+                  { rowIndex: 3, columnIndex: 1, color: "" },
+                  { rowIndex: 3, columnIndex: 2, color: "" },
+                  { rowIndex: 3, columnIndex: 3, color: "" },
+                ],
+              ]);
+            }}
+          >
+            Set Data to 4 X 4
+          </button>
+          <button
+            style={{
+              padding: "5px 10px",
+              background: "none",
+            }}
+            onClick={() => {
+              setData([
+                [
+                  { rowIndex: 0, columnIndex: 0, color: "" },
+                  { rowIndex: 0, columnIndex: 1, color: "" },
+                  { rowIndex: 0, columnIndex: 2, color: "" },
+                  { rowIndex: 0, columnIndex: 3, color: "" },
+                  { rowIndex: 0, columnIndex: 4, color: "" },
+                ],
+                [
+                  { rowIndex: 1, columnIndex: 0, color: "" },
+                  { rowIndex: 1, columnIndex: 1, color: "" },
+                  { rowIndex: 1, columnIndex: 2, color: "" },
+                  { rowIndex: 1, columnIndex: 3, color: "" },
+                  { rowIndex: 1, columnIndex: 4, color: "" },
+                ],
+                [
+                  { rowIndex: 2, columnIndex: 0, color: "" },
+                  { rowIndex: 2, columnIndex: 1, color: "" },
+                  { rowIndex: 2, columnIndex: 2, color: "" },
+                  { rowIndex: 2, columnIndex: 3, color: "" },
+                  { rowIndex: 2, columnIndex: 4, color: "" },
+                ],
+                [
+                  { rowIndex: 3, columnIndex: 0, color: "" },
+                  { rowIndex: 3, columnIndex: 1, color: "" },
+                  { rowIndex: 3, columnIndex: 2, color: "" },
+                  { rowIndex: 3, columnIndex: 3, color: "" },
+                  { rowIndex: 3, columnIndex: 4, color: "" },
+                ],
+                [
+                  { rowIndex: 4, columnIndex: 0, color: "" },
+                  { rowIndex: 4, columnIndex: 1, color: "" },
+                  { rowIndex: 4, columnIndex: 2, color: "" },
+                  { rowIndex: 4, columnIndex: 3, color: "" },
+                  { rowIndex: 4, columnIndex: 4, color: "" },
+                ],
+              ]);
+            }}
+          >
+            Set Data to 5 X 5
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SetData;

--- a/stories/useDottingComponents/SetData.tsx
+++ b/stories/useDottingComponents/SetData.tsx
@@ -5,11 +5,8 @@ import useDotting from "../../src/hooks/useDotting";
 
 const SetData = () => {
   const ref = useRef<DottingRef>(null);
-  const { colorPixels, erasePixels, setData } = useDotting(ref);
-  const [rowIndex, setRowIndex] = React.useState(0);
-  const [columnIndex, setColumnIndex] = React.useState(0);
-  const [rowIndex2, setRowIndex2] = React.useState(0);
-  const [columnIndex2, setColumnIndex2] = React.useState(0);
+  const { setData } = useDotting(ref);
+
   return (
     <div
       style={{

--- a/stories/useDottingComponents/index.ts
+++ b/stories/useDottingComponents/index.ts
@@ -2,6 +2,7 @@ import Clear from "./Clear";
 import ColorPixels from "./ColorPixels";
 import DownloadImage from "./DownloadImage";
 import GridStyling from "./GridStyling";
+import SetData from "./SetData";
 import SetIndicatorPixels from "./SetIndicatorPixels";
 import UndoRedo from "./UndoRedo";
 
@@ -12,4 +13,5 @@ export {
   SetIndicatorPixels,
   GridStyling,
   UndoRedo,
+  SetData,
 };


### PR DESCRIPTION
🚀 [Related Issue: #49 #50 #39]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

https://github.com/hunkim98/dotting/assets/57612141/d4c9b2f0-1d92-43e2-94a6-959022695a78

https://github.com/hunkim98/dotting/assets/57612141/405f6fcc-543f-44ed-8933-7d4b710ccec2



<br/>

### Changes

<!-- Name a title to your changes -->

## Add feature `setData` for setting pixel data with code

- **[🪝Hooks] Add `setData` function in `useDotting`**

  - Users can use function `setData` in `useDotting` hook to set pixel data

- **[🎨Component] Create functions to setData**

  - Create function in `Editor.tsx` to allow setting data with `PixelModifyItem` 2d array

- **[📒Docs] Add `setData` example**

  - In `useDotting` hook examples, I have added `setData` example where users can test the function by setting pixel data into 3x3, 4x4, 5x5 pixel data

<br/>

## Allow brush pattern to be changed with `useBrush` hook

- **[🪝Hooks] Add `setBrushPattern` function in `useBrush` hook**

  - Users can set their desired brush pattern with `setBrushPattern` in the `useBrush` hook

- **[🎨Component] Allow brush pattern to be tracked**

  - Add brushPattern member variable in InteractionLayer 
  - Update onmousedown function to be applied correctly according to the selected brush pattern.

- **[📒Docs] Add `setBrushPattern` example**

  - Users can test `setBrushPattern` function in `useBrush` hook examples. 

<br/>

## Fix pixel data not rendering when undo/redo is called

- **[🎨Component] Trigger event when undo/redo is called**

  - Previously, undo/redo did not emit any change event. I changed the `commitAction` function to trigger all events when undo/redo is called

## Notes

- There are some things that I would like to discuss with you.

<br/>

## Next Up?

