### PR TITLE
Feature: Change UI for extension buttons + Mask extended/shrinked area during interaction  + Remove/Add Dotting Props

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,19 +12,19 @@
 
 ## Write a title of your change
 
-- **[🪝Hooks] Write a summary of what you have done on hooks**
+- _[🪝Hooks] Write a summary of what you have done on hooks_
 
   - Write a description of the changes you made on hooks
 
-- **[🎨Component] Write a summary of what you have done on hooks**
+- _[🎨Component] Write a summary of what you have done on hooks_
 
   - Write a description of the changes you made on components
 
-- **[📒Docs] Write a summary of what you have done on docs**
+- _[📒Docs] Write a summary of what you have done on docs_
 
   - Write a description of the changes you made on docs
 
-- **[🔗Other] Write a summary of what other things you have done**
+- _[🔗Other] Write a summary of what other things you have done_
 
   - Write a description of the changes you made on other things
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,7 +12,7 @@ export const parameters = {
   options: {
     storySort: {
       // Introduction will be shown first
-      order: ["Introduction", "Customization", "Components", "Hooks"],
+      order: ["Introduction", "Customization", "Components", "Hooks", "Hooks/Setup"],
     },
   },
 };

--- a/src/components/Canvas/BackgroundLayer.tsx
+++ b/src/components/Canvas/BackgroundLayer.tsx
@@ -4,7 +4,7 @@ import { BaseLayer } from "./BaseLayer";
 
 export default class BackgroundLayer extends BaseLayer {
   private backgroundMode: "checkerboard" | "color";
-  private backgroundColor: React.CSSProperties["color"] = "#c9c9c9";
+  private backgroundColor: React.CSSProperties["color"] = "#999999";
   private backgroundAlpha: number;
 
   constructor({ canvas }: { canvas: HTMLCanvasElement }) {
@@ -12,7 +12,7 @@ export default class BackgroundLayer extends BaseLayer {
   }
 
   setBackgroundMode(backgroundMode?: "checkerboard" | "color") {
-    this.backgroundMode = backgroundMode ? backgroundMode : "checkerboard";
+    this.backgroundMode = backgroundMode ? backgroundMode : "color";
   }
 
   setBackgroundAlpha(alpha?: number) {
@@ -29,7 +29,7 @@ export default class BackgroundLayer extends BaseLayer {
   }
 
   setBackgroundColor(color?: React.CSSProperties["color"]) {
-    this.backgroundColor = color ? color : "#c9c9c9";
+    this.backgroundColor = color ? color : "#999999";
   }
 
   render() {

--- a/src/components/Canvas/BackgroundLayer.tsx
+++ b/src/components/Canvas/BackgroundLayer.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 
 import { BaseLayer } from "./BaseLayer";
+import { DefaultBackgroundColor } from "./config";
 
 export default class BackgroundLayer extends BaseLayer {
   private backgroundMode: "checkerboard" | "color";
-  private backgroundColor: React.CSSProperties["color"] = "#999999";
+  private backgroundColor: React.CSSProperties["color"] =
+    DefaultBackgroundColor;
   private backgroundAlpha: number;
 
   constructor({ canvas }: { canvas: HTMLCanvasElement }) {
@@ -17,19 +19,13 @@ export default class BackgroundLayer extends BaseLayer {
 
   setBackgroundAlpha(alpha?: number) {
     if (alpha === undefined) {
-      this.backgroundAlpha = 0.5;
+      this.backgroundAlpha = 1;
     }
-    this.backgroundAlpha = alpha
-      ? alpha >= 1
-        ? 1
-        : alpha < 0
-        ? 0
-        : alpha
-      : 0.5;
+    this.backgroundAlpha = alpha ? (alpha >= 1 ? 1 : alpha < 0 ? 0 : alpha) : 1;
   }
 
   setBackgroundColor(color?: React.CSSProperties["color"]) {
-    this.backgroundColor = color ? color : "#999999";
+    this.backgroundColor = color ? color : DefaultBackgroundColor;
   }
 
   render() {

--- a/src/components/Canvas/BackgroundLayer.tsx
+++ b/src/components/Canvas/BackgroundLayer.tsx
@@ -4,7 +4,7 @@ import { BaseLayer } from "./BaseLayer";
 import { DefaultBackgroundColor } from "./config";
 
 export default class BackgroundLayer extends BaseLayer {
-  private backgroundMode: "checkerboard" | "color";
+  private backgroundMode: "checkerboard" | "color" = "color";
   private backgroundColor: React.CSSProperties["color"] =
     DefaultBackgroundColor;
   private backgroundAlpha: number;

--- a/src/components/Canvas/BackgroundLayer.tsx
+++ b/src/components/Canvas/BackgroundLayer.tsx
@@ -7,7 +7,6 @@ export default class BackgroundLayer extends BaseLayer {
   private backgroundMode: "checkerboard" | "color" = "color";
   private backgroundColor: React.CSSProperties["color"] =
     DefaultBackgroundColor;
-  private backgroundAlpha: number;
 
   constructor({ canvas }: { canvas: HTMLCanvasElement }) {
     super({ canvas });
@@ -15,13 +14,6 @@ export default class BackgroundLayer extends BaseLayer {
 
   setBackgroundMode(backgroundMode?: "checkerboard" | "color") {
     this.backgroundMode = backgroundMode ? backgroundMode : "color";
-  }
-
-  setBackgroundAlpha(alpha?: number) {
-    if (alpha === undefined) {
-      this.backgroundAlpha = 1;
-    }
-    this.backgroundAlpha = alpha ? (alpha >= 1 ? 1 : alpha < 0 ? 0 : alpha) : 1;
   }
 
   setBackgroundColor(color?: React.CSSProperties["color"]) {
@@ -33,7 +25,6 @@ export default class BackgroundLayer extends BaseLayer {
     ctx.clearRect(0, 0, this.width, this.height);
     ctx.save();
 
-    ctx.globalAlpha = this.backgroundAlpha;
     if (this.backgroundMode === "color") {
       ctx.fillStyle = this.backgroundColor;
       ctx.fillRect(0, 0, this.width, this.height);

--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -259,6 +259,10 @@ export default class DataLayer extends BaseLayer {
     }
   }
 
+  setGridSquareLength(length: number) {
+    this.gridSquareLength = length;
+  }
+
   shortenGridBy(
     direction: ButtonDirection,
     amount: number,

--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -2,6 +2,7 @@ import { BaseLayer } from "./BaseLayer";
 import {
   ButtonDirection,
   DefaultGridSquareLength,
+  DefaultPixelColor,
   DefaultPixelDataDimensions,
 } from "./config";
 import {
@@ -30,7 +31,7 @@ export default class DataLayer extends BaseLayer {
   private gridSquareLength: number = DefaultGridSquareLength;
   private layers: Array<DottingDataLayer>;
   private currentLayer: DottingDataLayer;
-  private defaultPixelColor = "#ffffff";
+  private defaultPixelColor = DefaultPixelColor;
 
   constructor({
     canvas,

--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -30,6 +30,7 @@ export default class DataLayer extends BaseLayer {
   private gridSquareLength: number = DefaultGridSquareLength;
   private layers: Array<DottingDataLayer>;
   private currentLayer: DottingDataLayer;
+  private defaultPixelColor: string = "#ffffff";
 
   constructor({
     canvas,
@@ -261,6 +262,10 @@ export default class DataLayer extends BaseLayer {
 
   setGridSquareLength(length: number) {
     this.gridSquareLength = length;
+  }
+
+  setDefaultPixelColor(color: string) {
+    this.defaultPixelColor = color;
   }
 
   shortenGridBy(
@@ -516,6 +521,19 @@ export default class DataLayer extends BaseLayer {
 
     const allRowKeys = getRowKeysFromData(this.getData());
     const allColumnKeys = getColumnKeysFromData(this.getData());
+
+    // color back with default color
+    if (this.defaultPixelColor) {
+      ctx.save();
+      ctx.fillStyle = this.defaultPixelColor;
+      ctx.fillRect(
+        correctedLeftTopScreenPoint.x,
+        correctedLeftTopScreenPoint.y,
+        squareLength * allColumnKeys.length,
+        squareLength * allRowKeys.length,
+      );
+      ctx.restore();
+    }
 
     ctx.save();
     for (const i of allRowKeys) {

--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -30,7 +30,7 @@ export default class DataLayer extends BaseLayer {
   private gridSquareLength: number = DefaultGridSquareLength;
   private layers: Array<DottingDataLayer>;
   private currentLayer: DottingDataLayer;
-  private defaultPixelColor: string = "#ffffff";
+  private defaultPixelColor = "#ffffff";
 
   constructor({
     canvas,

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -318,6 +318,17 @@ export default class Editor extends EventDispatcher {
     this.renderGridLayer();
   }
 
+  setGridSquareLength(length: number) {
+    if (length === 0 || length === undefined) {
+      return;
+    }
+    this.gridSquareLength = length;
+    this.gridLayer.setGridSquareLength(length);
+    this.interactionLayer.setGridSquareLength(length);
+    this.dataLayer.setGridSquareLength(length);
+    this.renderAll();
+  }
+
   setIsGridVisible(isGridVisible: boolean) {
     this.gridLayer.setIsGridVisible(isGridVisible);
     this.renderGridLayer();

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -343,12 +343,18 @@ export default class Editor extends EventDispatcher {
     if (minScale === undefined) {
       return;
     }
+    if (minScale > this.maxScale) {
+      throw new Error("minScale cannot be greater than maxScale");
+    }
     this.minScale = minScale;
   }
 
   setMaxScale(maxScale: number) {
     if (maxScale === undefined) {
       return;
+    }
+    if (maxScale < this.minScale) {
+      throw new Error("maxScale cannot be less than minScale");
     }
     this.maxScale = maxScale;
   }

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -284,11 +284,6 @@ export default class Editor extends EventDispatcher {
     this.renderBackgroundLayer();
   }
 
-  setBackgroundAlpha(alpha: number) {
-    this.backgroundLayer.setBackgroundAlpha(alpha);
-    this.renderBackgroundLayer();
-  }
-
   setBackgroundColor(color: React.CSSProperties["color"]) {
     this.backgroundLayer.setBackgroundColor(color);
     this.interactionLayer.setBackgroundColor(color);

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -339,6 +339,20 @@ export default class Editor extends EventDispatcher {
     this.renderAll();
   }
 
+  setMinScale(minScale: number) {
+    if (minScale === undefined) {
+      return;
+    }
+    this.minScale = minScale;
+  }
+
+  setMaxScale(maxScale: number) {
+    if (maxScale === undefined) {
+      return;
+    }
+    this.maxScale = maxScale;
+  }
+
   setIsGridVisible(isGridVisible: boolean) {
     this.gridLayer.setIsGridVisible(isGridVisible);
     this.renderGridLayer();
@@ -421,6 +435,14 @@ export default class Editor extends EventDispatcher {
 
   getGridSquareLength() {
     return this.gridSquareLength;
+  }
+
+  getMinScale() {
+    return this.minScale;
+  }
+
+  getMaxScale() {
+    return this.maxScale;
   }
 
   styleMouseCursor = (mouseCoord: Coord) => {

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -291,6 +291,7 @@ export default class Editor extends EventDispatcher {
 
   setBackgroundColor(color: React.CSSProperties["color"]) {
     this.backgroundLayer.setBackgroundColor(color);
+    this.interactionLayer.setBackgroundColor(color);
     this.renderBackgroundLayer();
   }
   // background related functions ⬆
@@ -316,6 +317,15 @@ export default class Editor extends EventDispatcher {
   setGridStrokeWidth(width: number) {
     this.gridLayer.setGridStrokeWidth(width);
     this.renderGridLayer();
+  }
+
+  setDefaultPixelColor(color: string) {
+    if (color === undefined) {
+      return;
+    }
+    this.dataLayer.setDefaultPixelColor(color);
+    this.interactionLayer.setDefaultPixelColor(color);
+    this.renderDataLayer();
   }
 
   setGridSquareLength(length: number) {

--- a/src/components/Canvas/GridLayer.tsx
+++ b/src/components/Canvas/GridLayer.tsx
@@ -624,7 +624,7 @@ export default class GridLayer extends BaseLayer {
 
   drawButtons() {
     const buttonBackgroundColor = "transparent";
-    const onHoverbuttonBackgroundColor = "#b2b2b2";
+    const onHoverbuttonBackgroundColor = "rgba(50,50,50,0.4)";
     this.drawTopButton(
       this.hoveredButton === ButtonDirection.TOP
         ? onHoverbuttonBackgroundColor

--- a/src/components/Canvas/GridLayer.tsx
+++ b/src/components/Canvas/GridLayer.tsx
@@ -612,14 +612,7 @@ export default class GridLayer extends BaseLayer {
       x: correctedLefTopScreenPoint.x - offsetFromPixelCanvas,
       y: correctedLefTopScreenPoint.y + (this.rowCount * squareLength) / 2,
     };
-    drawCircle(ctx, leftTopCorner, radius, "#ffffff", "#5A7FF7", 1);
-    drawCircle(ctx, topMiddle, radius, "#ffffff", "#5A7FF7", 1);
-    drawCircle(ctx, rightTopCorner, radius, "#ffffff", "#5A7FF7", 1);
-    drawCircle(ctx, rightMiddle, radius, "#ffffff", "#5A7FF7", 1);
-    drawCircle(ctx, rightBottomCorner, radius, "#ffffff", "#5A7FF7", 1);
-    drawCircle(ctx, bottomMiddle, radius, "#ffffff", "#5A7FF7", 1);
-    drawCircle(ctx, leftBottomCorner, radius, "#ffffff", "#5A7FF7", 1);
-    drawCircle(ctx, leftMiddle, radius, "#ffffff", "#5A7FF7", 1);
+  [leftTopCorner, topMiddle, rightTopCorner, rightMiddle, rightBottomCorner, bottomMiddle, leftBottomCorner, leftMiddle].forEach((position) => drawCircle(ctx, position, radius,"#ffffff", "#5A7FF7", 1 ))
   }
 
   drawButtons() {

--- a/src/components/Canvas/GridLayer.tsx
+++ b/src/components/Canvas/GridLayer.tsx
@@ -137,6 +137,10 @@ export default class GridLayer extends BaseLayer {
     }
   }
 
+  setGridSquareLength(gridSquareLength: number) {
+    this.gridSquareLength = gridSquareLength;
+  }
+
   getGridStrokeColor() {
     return this.gridStrokeColor;
   }

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -59,7 +59,7 @@ export default class InteractionLayer extends BaseLayer {
   private backgroundColor: React.CSSProperties["color"] =
     DefaultBackgroundColor;
 
-  private defaultPixelColor: string = "#ffffff";
+  private defaultPixelColor = "#ffffff";
 
   private selectingArea: Omit<
     SelectAreaRange,

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -134,6 +134,10 @@ export default class InteractionLayer extends BaseLayer {
     this.brushPattern = pattern;
   }
 
+  setGridSquareLength(length: number) {
+    this.gridSquareLength = length;
+  }
+
   setDataLayerColumnCount(columnCount: number) {
     this.dataLayerColumnCount = columnCount;
   }

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -9,6 +9,7 @@ import {
   UserId,
   CurrentDeviceUserId,
   DefaultBackgroundColor,
+  DefaultPixelColor,
 } from "./config";
 import {
   BRUSH_PATTERN_ELEMENT,
@@ -59,7 +60,9 @@ export default class InteractionLayer extends BaseLayer {
   private backgroundColor: React.CSSProperties["color"] =
     DefaultBackgroundColor;
 
-  private defaultPixelColor = "#ffffff";
+  private defaultPixelColor = DefaultPixelColor;
+
+  private backgroundMode: "checkerboard" | "color" = "color";
 
   private selectingArea: Omit<
     SelectAreaRange,
@@ -1389,7 +1392,17 @@ export default class InteractionLayer extends BaseLayer {
     ctx.restore();
   }
 
+  /**
+   * @description While user is extending the pixel canvas,
+   *              this function hides the datalayer with background color when canvas is shrinked
+   *              or notifies the extended area with DefaultPixelColor when canvas is extended
+   * @param correctedLeftTopScreenPoint The left top point of the canvas
+   * @param squareLength The length of the square
+   * @returns void
+   */
   renderCanvasMask(correctedLeftTopScreenPoint: Coord, squareLength: number) {
+    // TODO: this function only works for background mode "color"
+    //       We need to implement this function for "checkboard" mode
     if (
       this.capturedData === null ||
       this.capturedDataOriginalIndices === null

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -38,6 +38,7 @@ import {
   lerpRanges,
 } from "../../utils/math";
 import { getOverlappingPixelIndicesForModifiedPixels } from "../../utils/position";
+import { drawRect } from "../../utils/shapes";
 
 export default class InteractionLayer extends BaseLayer {
   // We make this a map to allow for multiple users to interact with the canvas
@@ -1427,128 +1428,150 @@ export default class InteractionLayer extends BaseLayer {
     const bottomRowOffset =
       modifiedGridIndices.bottomRowIndex - originalGridIndices.bottomRowIndex;
     const ctx = this.ctx;
-    ctx.save();
     if (leftColumnOffset > 0) {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.strokeStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x - leftColumnOffset * squareLength,
         correctedLeftTopScreenPoint.y,
         leftColumnOffset * squareLength,
         rowCount * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     } else {
-      ctx.fillStyle = this.defaultPixelColor;
-      ctx.strokeStyle = this.defaultPixelColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y,
         -leftColumnOffset * squareLength,
         rowCount * squareLength,
+        this.defaultPixelColor,
+        this.defaultPixelColor,
+        1,
       );
     }
     if (rightColumnOffset > 0) {
-      ctx.fillStyle = this.defaultPixelColor;
-      ctx.strokeStyle = this.defaultPixelColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x +
           columnCount * squareLength -
           rightColumnOffset * squareLength,
         correctedLeftTopScreenPoint.y,
         rightColumnOffset * squareLength,
         rowCount * squareLength,
+        this.defaultPixelColor,
+        this.defaultPixelColor,
+        1,
       );
     } else {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.strokeStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x + columnCount * squareLength,
         correctedLeftTopScreenPoint.y,
         -rightColumnOffset * squareLength,
         rowCount * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     }
     if (topRowOffset > 0) {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y - topRowOffset * squareLength,
         columnCount * squareLength,
         topRowOffset * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     } else {
-      ctx.fillStyle = this.defaultPixelColor;
-      ctx.strokeStyle = this.defaultPixelColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y,
         columnCount * squareLength,
         -topRowOffset * squareLength,
+        this.defaultPixelColor,
+        this.defaultPixelColor,
+        1,
       );
     }
     if (bottomRowOffset > 0) {
-      ctx.fillStyle = this.defaultPixelColor;
-      ctx.strokeStyle = this.defaultPixelColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y +
           rowCount * squareLength -
           bottomRowOffset * squareLength,
         columnCount * squareLength,
         bottomRowOffset * squareLength,
+        this.defaultPixelColor,
+        this.defaultPixelColor,
+        1,
       );
     } else {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.strokeStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y + rowCount * squareLength,
         columnCount * squareLength,
         -bottomRowOffset * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     }
     if (leftColumnOffset > 0 && topRowOffset > 0) {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.strokeStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x - leftColumnOffset * squareLength,
         correctedLeftTopScreenPoint.y - topRowOffset * squareLength,
         leftColumnOffset * squareLength,
         topRowOffset * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     }
     if (leftColumnOffset > 0 && bottomRowOffset < 0) {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.strokeStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x - leftColumnOffset * squareLength,
         correctedLeftTopScreenPoint.y + rowCount * squareLength,
         leftColumnOffset * squareLength,
         -bottomRowOffset * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     }
     if (rightColumnOffset < 0 && topRowOffset > 0) {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.strokeStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x + columnCount * squareLength,
         correctedLeftTopScreenPoint.y - topRowOffset * squareLength,
         -rightColumnOffset * squareLength,
         topRowOffset * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     }
     if (rightColumnOffset < 0 && bottomRowOffset < 0) {
-      ctx.fillStyle = this.backgroundColor;
-      ctx.strokeStyle = this.backgroundColor;
-      ctx.fillRect(
+      drawRect(
+        ctx,
         correctedLeftTopScreenPoint.x + columnCount * squareLength,
         correctedLeftTopScreenPoint.y + rowCount * squareLength,
         -rightColumnOffset * squareLength,
         -bottomRowOffset * squareLength,
+        this.backgroundColor,
+        this.backgroundColor,
+        1,
       );
     }
-    ctx.stroke();
-    ctx.restore();
   }
 
   renderIndicatorPixels(

--- a/src/components/Canvas/InteractionLayer.tsx
+++ b/src/components/Canvas/InteractionLayer.tsx
@@ -1430,6 +1430,7 @@ export default class InteractionLayer extends BaseLayer {
     ctx.save();
     if (leftColumnOffset > 0) {
       ctx.fillStyle = this.backgroundColor;
+      ctx.strokeStyle = this.backgroundColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x - leftColumnOffset * squareLength,
         correctedLeftTopScreenPoint.y,
@@ -1438,6 +1439,7 @@ export default class InteractionLayer extends BaseLayer {
       );
     } else {
       ctx.fillStyle = this.defaultPixelColor;
+      ctx.strokeStyle = this.defaultPixelColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y,
@@ -1447,6 +1449,7 @@ export default class InteractionLayer extends BaseLayer {
     }
     if (rightColumnOffset > 0) {
       ctx.fillStyle = this.defaultPixelColor;
+      ctx.strokeStyle = this.defaultPixelColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x +
           columnCount * squareLength -
@@ -1457,6 +1460,7 @@ export default class InteractionLayer extends BaseLayer {
       );
     } else {
       ctx.fillStyle = this.backgroundColor;
+      ctx.strokeStyle = this.backgroundColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x + columnCount * squareLength,
         correctedLeftTopScreenPoint.y,
@@ -1474,6 +1478,7 @@ export default class InteractionLayer extends BaseLayer {
       );
     } else {
       ctx.fillStyle = this.defaultPixelColor;
+      ctx.strokeStyle = this.defaultPixelColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y,
@@ -1483,6 +1488,7 @@ export default class InteractionLayer extends BaseLayer {
     }
     if (bottomRowOffset > 0) {
       ctx.fillStyle = this.defaultPixelColor;
+      ctx.strokeStyle = this.defaultPixelColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y +
@@ -1493,6 +1499,7 @@ export default class InteractionLayer extends BaseLayer {
       );
     } else {
       ctx.fillStyle = this.backgroundColor;
+      ctx.strokeStyle = this.backgroundColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x,
         correctedLeftTopScreenPoint.y + rowCount * squareLength,
@@ -1502,6 +1509,7 @@ export default class InteractionLayer extends BaseLayer {
     }
     if (leftColumnOffset > 0 && topRowOffset > 0) {
       ctx.fillStyle = this.backgroundColor;
+      ctx.strokeStyle = this.backgroundColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x - leftColumnOffset * squareLength,
         correctedLeftTopScreenPoint.y - topRowOffset * squareLength,
@@ -1511,6 +1519,7 @@ export default class InteractionLayer extends BaseLayer {
     }
     if (leftColumnOffset > 0 && bottomRowOffset < 0) {
       ctx.fillStyle = this.backgroundColor;
+      ctx.strokeStyle = this.backgroundColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x - leftColumnOffset * squareLength,
         correctedLeftTopScreenPoint.y + rowCount * squareLength,
@@ -1520,6 +1529,7 @@ export default class InteractionLayer extends BaseLayer {
     }
     if (rightColumnOffset < 0 && topRowOffset > 0) {
       ctx.fillStyle = this.backgroundColor;
+      ctx.strokeStyle = this.backgroundColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x + columnCount * squareLength,
         correctedLeftTopScreenPoint.y - topRowOffset * squareLength,
@@ -1529,6 +1539,7 @@ export default class InteractionLayer extends BaseLayer {
     }
     if (rightColumnOffset < 0 && bottomRowOffset < 0) {
       ctx.fillStyle = this.backgroundColor;
+      ctx.strokeStyle = this.backgroundColor;
       ctx.fillRect(
         correctedLeftTopScreenPoint.x + columnCount * squareLength,
         correctedLeftTopScreenPoint.y + rowCount * squareLength,
@@ -1536,6 +1547,7 @@ export default class InteractionLayer extends BaseLayer {
         -bottomRowOffset * squareLength,
       );
     }
+    ctx.stroke();
     ctx.restore();
   }
 

--- a/src/components/Canvas/config.ts
+++ b/src/components/Canvas/config.ts
@@ -60,3 +60,5 @@ export const DashedLineOffsetFromPixelCanvas = 15;
 export const ExtensionGuideCircleRadius = 3;
 
 export const DefaultExtendArrowPadding = 2;
+
+export const DefaultBackgroundColor = "#999999";

--- a/src/components/Canvas/config.ts
+++ b/src/components/Canvas/config.ts
@@ -62,3 +62,5 @@ export const ExtensionGuideCircleRadius = 3;
 export const DefaultExtendArrowPadding = 2;
 
 export const DefaultBackgroundColor = "#999999";
+
+export const DefaultPixelColor = "#ffffff";

--- a/src/components/Canvas/config.ts
+++ b/src/components/Canvas/config.ts
@@ -7,7 +7,7 @@ export const DefaultPanZoom: PanZoom = {
 
 export const DefaultGridSquareLength = 20;
 
-export const DefaultButtonHeight = 20;
+export const DefaultButtonHeight = 30;
 
 export enum ButtonDirection {
   TOP = "TOP",
@@ -54,3 +54,9 @@ export const InteractionExtensionAllowanceRatio = 2;
 export const InteractionEdgeTouchingRange = 6;
 
 export const DefaultPixelExtendRatio = 1;
+
+export const DashedLineOffsetFromPixelCanvas = 15;
+
+export const ExtensionGuideCircleRadius = 3;
+
+export const DefaultExtendArrowPadding = 2;

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -43,6 +43,7 @@ export interface DottingProps {
   indicatorData?: Array<PixelModifyItem>;
   isInteractionApplicable?: boolean;
   isDrawingEnabled?: boolean;
+  gridSquareLength?: number;
   // children?: React.ReactNode;
   // initIndicatorData?: Array<PixelModifyItem>;
   // initBrushColor?: string;
@@ -196,6 +197,13 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     }
     editor.setIsPanZoomable(props.isPanZoomable);
   }, [editor, props.isPanZoomable]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+    editor.setGridSquareLength(props.gridSquareLength);
+  }, [editor, props.gridSquareLength]);
 
   useEffect(() => {
     if (!editor) {
@@ -454,11 +462,9 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     editor.setBackgroundAlpha(props.backgroundAlpha);
     editor.setBackgroundMode(props.backgroundMode);
     editor.setIsPanZoomable(props.isPanZoomable);
-
+    editor.setGridSquareLength(props.gridSquareLength);
     editor.setIsGridVisible(props.isGridVisible);
-
     editor.setGridStrokeColor(props.gridStrokeColor);
-
     editor.setGridStrokeWidth(props.gridStrokeWidth);
 
     setEditor(editor);

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -44,6 +44,7 @@ export interface DottingProps {
   isInteractionApplicable?: boolean;
   isDrawingEnabled?: boolean;
   gridSquareLength?: number;
+  defaultPixelColor?: string;
   // children?: React.ReactNode;
   // initIndicatorData?: Array<PixelModifyItem>;
   // initBrushColor?: string;
@@ -202,6 +203,13 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     if (!editor) {
       return;
     }
+    editor.setIsInteractionApplicable(props.isInteractionApplicable);
+  }, [editor, props.isInteractionApplicable]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
     editor.setGridSquareLength(props.gridSquareLength);
   }, [editor, props.gridSquareLength]);
 
@@ -209,8 +217,8 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     if (!editor) {
       return;
     }
-    editor.setIsInteractionApplicable(props.isInteractionApplicable);
-  }, [editor, props.isInteractionApplicable]);
+    editor.setDefaultPixelColor(props.defaultPixelColor);
+  }, [editor, props.defaultPixelColor]);
 
   useEffect(() => {
     if (!editor) {
@@ -462,10 +470,11 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     editor.setBackgroundAlpha(props.backgroundAlpha);
     editor.setBackgroundMode(props.backgroundMode);
     editor.setIsPanZoomable(props.isPanZoomable);
-    editor.setGridSquareLength(props.gridSquareLength);
     editor.setIsGridVisible(props.isGridVisible);
     editor.setGridStrokeColor(props.gridStrokeColor);
     editor.setGridStrokeWidth(props.gridStrokeWidth);
+    editor.setGridSquareLength(props.gridSquareLength);
+    editor.setDefaultPixelColor(props.defaultPixelColor);
 
     setEditor(editor);
 

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -45,6 +45,8 @@ export interface DottingProps {
   isDrawingEnabled?: boolean;
   gridSquareLength?: number;
   defaultPixelColor?: string;
+  minScale?: number;
+  maxScale?: number;
   // children?: React.ReactNode;
   // initIndicatorData?: Array<PixelModifyItem>;
   // initBrushColor?: string;
@@ -219,6 +221,20 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     }
     editor.setDefaultPixelColor(props.defaultPixelColor);
   }, [editor, props.defaultPixelColor]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+    editor.setMinScale(props.minScale);
+  }, [editor, props.minScale]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+    editor.setMaxScale(props.maxScale);
+  }, [editor, props.maxScale]);
 
   useEffect(() => {
     if (!editor) {
@@ -475,6 +491,8 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     editor.setGridStrokeWidth(props.gridStrokeWidth);
     editor.setGridSquareLength(props.gridSquareLength);
     editor.setDefaultPixelColor(props.defaultPixelColor);
+    editor.setMinScale(props.minScale);
+    editor.setMaxScale(props.maxScale);
 
     setEditor(editor);
 

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -37,7 +37,6 @@ export interface DottingProps {
   //       backgroundMode "checkerboard"
   // backgroundMode?: "checkerboard" | "color";
   backgroundColor?: string;
-  backgroundAlpha?: number;
   initLayers?: Array<LayerProps>;
   isPanZoomable?: boolean;
   isGridFixed?: boolean;
@@ -373,9 +372,6 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     if (!editor) {
       return;
     }
-    if (props.backgroundAlpha) {
-      editor.setBackgroundAlpha(props.backgroundAlpha);
-    }
     if (props.backgroundColor) {
       editor.setBackgroundColor(props.backgroundColor);
     }
@@ -385,7 +381,6 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
   }, [
     editor,
     // props.backgroundMode,
-    props.backgroundAlpha,
     props.backgroundColor,
   ]);
 
@@ -468,7 +463,6 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     editor.setIsGridFixed(props.isGridFixed);
     editor.setIsInteractionApplicable(props.isInteractionApplicable);
     editor.setIsDrawingEnabled(props.isDrawingEnabled);
-    editor.setBackgroundAlpha(props.backgroundAlpha);
     // editor.setBackgroundMode(props.backgroundMode);
     editor.setIsPanZoomable(props.isPanZoomable);
     editor.setIsGridVisible(props.isGridVisible);

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -32,7 +32,10 @@ export interface DottingProps {
   gridStrokeColor?: string;
   gridStrokeWidth?: number;
   isGridVisible?: boolean;
-  backgroundMode?: "checkerboard" | "color";
+  // TODO: The background mode has been removed for now
+  //       This is because the `renderCanvasMask` function in interactionLayer does not work for
+  //       backgroundMode "checkerboard"
+  // backgroundMode?: "checkerboard" | "color";
   backgroundColor?: string;
   backgroundAlpha?: number;
   initLayers?: Array<LayerProps>;
@@ -147,24 +150,6 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
         listener: EventListenerOrEventListenerObject;
       }>
     >([]);
-
-  // this is called when children are added to the canvas
-  // this will be used when layers are reorderd or added/removed
-  // useEffect(() => {
-  //   if (!editor) {
-  //     return;
-  //   }
-  //   const layerIds = new Set<string>();
-  //   React.Children.map(props.children, (child: any) => {
-  //     const { id } = child.props;
-  //     if (layerIds.has(id)) {
-  //       throw new Error(`Duplicate layer id: ${id}`);
-  //     }
-  //     layerIds.add(id);
-
-  //     // editor.addCanvasElement(child);
-  //   });
-  // }, [editor, props.children]);
 
   useEffect(() => {
     if (!editor) {
@@ -394,12 +379,12 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     if (props.backgroundColor) {
       editor.setBackgroundColor(props.backgroundColor);
     }
-    if (props.backgroundMode) {
-      editor.setBackgroundMode(props.backgroundMode);
-    }
+    // if (props.backgroundMode) {
+    //   editor.setBackgroundMode(props.backgroundMode);
+    // }
   }, [
     editor,
-    props.backgroundMode,
+    // props.backgroundMode,
     props.backgroundAlpha,
     props.backgroundColor,
   ]);
@@ -484,7 +469,7 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     editor.setIsInteractionApplicable(props.isInteractionApplicable);
     editor.setIsDrawingEnabled(props.isDrawingEnabled);
     editor.setBackgroundAlpha(props.backgroundAlpha);
-    editor.setBackgroundMode(props.backgroundMode);
+    // editor.setBackgroundMode(props.backgroundMode);
     editor.setIsPanZoomable(props.isPanZoomable);
     editor.setIsGridVisible(props.isGridVisible);
     editor.setGridStrokeColor(props.gridStrokeColor);

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -93,7 +93,11 @@ export const deleteColumnOfData = (data: DottingData, columnIndex: number) => {
   });
 };
 
-export const addRowToData = (data: DottingData, rowIndex: number) => {
+export const addRowToData = (
+  data: DottingData,
+  rowIndex: number,
+  defaultColor: string,
+) => {
   const columnKeys = getColumnKeysFromData(data);
   if (data.has(rowIndex)) {
     return;
@@ -104,7 +108,11 @@ export const addRowToData = (data: DottingData, rowIndex: number) => {
   }
 };
 
-export const addColumnToData = (data: DottingData, columnIndex: number) => {
+export const addColumnToData = (
+  data: DottingData,
+  columnIndex: number,
+  defaultColor: string,
+) => {
   data.forEach(row => {
     if (!row.has(columnIndex)) {
       row.set(columnIndex, { color: "" });

--- a/src/utils/shapes.ts
+++ b/src/utils/shapes.ts
@@ -74,3 +74,24 @@ export const drawCircle = (
   ctx.stroke();
   ctx.restore();
 };
+
+export const drawRect = (
+  ctx: CanvasRenderingContext2D,
+  leftTopPosX: number,
+  leftTopPosY: number,
+  width: number,
+  height: number,
+  fillStyle: string,
+  strokeStyle: string,
+  lineWidth: number,
+) => {
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(leftTopPosX, leftTopPosY, width, height);
+  ctx.fillStyle = fillStyle;
+  ctx.lineWidth = lineWidth;
+  ctx.fill();
+  ctx.strokeStyle = strokeStyle;
+  ctx.stroke();
+  ctx.restore();
+};

--- a/src/utils/shapes.ts
+++ b/src/utils/shapes.ts
@@ -6,16 +6,30 @@ export const drawArrowHead = (
   y: number,
   radians: number,
   scale: number,
+  arrowWidth: number,
 ) => {
+  // draw traingle
   ctx.save();
   ctx.beginPath();
   ctx.translate(x, y);
   ctx.rotate(radians);
   ctx.moveTo(0, 0);
-  ctx.lineTo(7 * scale, 5 * scale);
-  ctx.lineTo(-7 * scale, 5 * scale);
+  ctx.lineTo((arrowWidth / 2) * scale, 5 * scale);
+  ctx.lineTo((-arrowWidth / 2) * scale, 5 * scale);
   ctx.closePath();
-  ctx.fillStyle = "#949494";
+  ctx.fillStyle = "#000000";
+  ctx.fill();
+  ctx.restore();
+  // draw line
+  ctx.save();
+  ctx.beginPath();
+  ctx.translate(x, y);
+  ctx.rotate(radians);
+  ctx.moveTo(0, 0);
+  ctx.lineTo(0, 8 * scale);
+  ctx.stroke();
+  ctx.closePath();
+  ctx.fillStyle = "#000000";
   ctx.fill();
   ctx.restore();
 };
@@ -39,5 +53,24 @@ export const drawExtendButton = (
     buttonHeight * scale,
   );
 
+  ctx.restore();
+};
+
+export const drawCircle = (
+  ctx: CanvasRenderingContext2D,
+  center: Coord,
+  radius: number,
+  fillStyle: string,
+  strokeStyle: string,
+  strokeWidth: number,
+) => {
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(center.x, center.y, radius, 0, 2 * Math.PI);
+  ctx.fillStyle = fillStyle;
+  ctx.fill();
+  ctx.lineWidth = strokeWidth;
+  ctx.strokeStyle = strokeStyle;
+  ctx.stroke();
   ctx.restore();
 };

--- a/stories/Dotting.stories.tsx
+++ b/stories/Dotting.stories.tsx
@@ -7,6 +7,12 @@ import {
 import { KeysEnum, StoriesComponentItem } from "./utils/types";
 import { BrushTool } from "../src/components/Canvas/types";
 import DottingComponent, { DottingProps } from "../src/components/Dotting";
+import {
+  DefaultGridSquareLength,
+  DefaultMaxScale,
+  DefaultMinScale,
+  DefaultPixelColor,
+} from "../src/components/Canvas/config";
 
 //blog.harveydelaney.com/creating-your-own-react-component-library/
 
@@ -44,11 +50,13 @@ const DottingComponentArgTypes: KeysEnum<
     description: "If set to `true` the grid lines will be visible",
     disable: false,
   }),
-  backgroundMode: generateComponentControl<DottingProps["backgroundMode"]>({
-    defaultValue: "checkerboard",
-    description: "The background mode of the canvas.",
-    disable: false,
-  }),
+  // TODO: backgroundMode "checkerboard" does not work for now due to the changes in interactionlayer
+  //       We must first tackle with `renderCanvasMask` to make backgroundMode to be set by users
+  // backgroundMode: generateComponentControl<DottingProps["backgroundMode"]>({
+  //   defaultValue: "checkerboard",
+  //   description: "The background mode of the canvas.",
+  //   disable: false,
+  // }),
   backgroundColor: generateComponentControl<DottingProps["backgroundColor"]>({
     defaultValue: "#c9c9c9",
     description: "The background color of the canvas.",
@@ -75,22 +83,7 @@ const DottingComponentArgTypes: KeysEnum<
     description: "If set to `true` the grid will not be extendable",
     disable: false,
   }),
-  isInteractionApplicable: generateComponentControl<
-    DottingProps["isInteractionApplicable"]
-  >({
-    defaultValue: true,
-    description:
-      "If set to `true` the interaction will be applicable.\
-      If set to `false` the interaction will be disabled",
-    disable: false,
-  }),
-  isDrawingEnabled: generateComponentControl<DottingProps["isDrawingEnabled"]>({
-    defaultValue: true,
-    description:
-      "If set to `true` the drawing will be enabled.\
-      If set to `false` the drawing will be disabled",
-    disable: false,
-  }),
+
   // ref: generateComponentControl<DottingProps["ref"]>({
   //   description:
   //     "The ref object that you would like to connect to the Dotting Canvas.\
@@ -114,6 +107,44 @@ const DottingComponentArgTypes: KeysEnum<
   indicatorData: generateComponentControl<DottingProps["indicatorData"]>({
     description: "The indicator data that you want to draw on the canvas.",
     disable: true,
+  }),
+  isInteractionApplicable: generateComponentControl<
+    DottingProps["isInteractionApplicable"]
+  >({
+    defaultValue: true,
+    description:
+      "If set to `true` the interaction will be applicable.\
+    If set to `false` the interaction will be disabled",
+    disable: false,
+  }),
+  isDrawingEnabled: generateComponentControl<DottingProps["isDrawingEnabled"]>({
+    defaultValue: true,
+    description:
+      "If set to `true` the drawing will be enabled.\
+      If set to `false` the drawing will be disabled",
+    disable: false,
+  }),
+  gridSquareLength: generateComponentControl<DottingProps["gridSquareLength"]>({
+    defaultValue: DefaultGridSquareLength,
+    description: "The length of the grid square.",
+    disable: false,
+  }),
+  defaultPixelColor: generateComponentControl<
+    DottingProps["defaultPixelColor"]
+  >({
+    defaultValue: DefaultPixelColor,
+    description: "The default pixel color.",
+    disable: false,
+  }),
+  minScale: generateComponentControl<DottingProps["minScale"]>({
+    defaultValue: DefaultMinScale,
+    description: "The minimum scale of the canvas.",
+    disable: false,
+  }),
+  maxScale: generateComponentControl<DottingProps["maxScale"]>({
+    defaultValue: DefaultMaxScale,
+    description: "The maximum scale of the canvas.",
+    disable: false,
   }),
 };
 
@@ -145,16 +176,20 @@ export const Dotting = (args: DottingProps) => {
       gridStrokeColor={args.gridStrokeColor}
       gridStrokeWidth={args.gridStrokeWidth}
       isGridVisible={args.isGridVisible}
-      backgroundMode={args.backgroundMode}
+      // backgroundMode={args.backgroundMode}
       backgroundColor={args.backgroundColor}
       backgroundAlpha={args.backgroundAlpha}
       isPanZoomable={args.isPanZoomable}
       isGridFixed={args.isGridFixed}
-      isInteractionApplicable={args.isInteractionApplicable}
-      isDrawingEnabled={args.isDrawingEnabled}
       brushColor={args.brushColor}
       brushTool={args.brushTool}
       indicatorData={[]}
+      isInteractionApplicable={args.isInteractionApplicable}
+      isDrawingEnabled={args.isDrawingEnabled}
+      gridSquareLength={args.gridSquareLength}
+      defaultPixelColor={args.defaultPixelColor}
+      minScale={args.minScale}
+      maxScale={args.maxScale}
     />
   );
 };

--- a/stories/Dotting.stories.tsx
+++ b/stories/Dotting.stories.tsx
@@ -5,14 +5,14 @@ import {
   generateComponentControlForEnum,
 } from "./utils/componentControl";
 import { KeysEnum, StoriesComponentItem } from "./utils/types";
-import { BrushTool } from "../src/components/Canvas/types";
-import DottingComponent, { DottingProps } from "../src/components/Dotting";
 import {
   DefaultGridSquareLength,
   DefaultMaxScale,
   DefaultMinScale,
   DefaultPixelColor,
 } from "../src/components/Canvas/config";
+import { BrushTool } from "../src/components/Canvas/types";
+import DottingComponent, { DottingProps } from "../src/components/Dotting";
 
 //blog.harveydelaney.com/creating-your-own-react-component-library/
 
@@ -60,11 +60,6 @@ const DottingComponentArgTypes: KeysEnum<
   backgroundColor: generateComponentControl<DottingProps["backgroundColor"]>({
     defaultValue: "#c9c9c9",
     description: "The background color of the canvas.",
-    disable: false,
-  }),
-  backgroundAlpha: generateComponentControl<DottingProps["backgroundAlpha"]>({
-    defaultValue: 0.5,
-    description: "The background alpha of the canvas.",
     disable: false,
   }),
   initLayers: generateComponentControl<DottingProps["initLayers"]>({
@@ -178,7 +173,6 @@ export const Dotting = (args: DottingProps) => {
       isGridVisible={args.isGridVisible}
       // backgroundMode={args.backgroundMode}
       backgroundColor={args.backgroundColor}
-      backgroundAlpha={args.backgroundAlpha}
       isPanZoomable={args.isPanZoomable}
       isGridFixed={args.isGridFixed}
       brushColor={args.brushColor}

--- a/stories/Hooks.stories.mdx
+++ b/stories/Hooks.stories.mdx
@@ -159,7 +159,7 @@ export const Component = () => {
         gridStrokeColor={gridStrokeColor}
         gridStrokeWidth={gridStrokeWidth}
         style={{ borderColor: "red" }}
-        backgroundColor="rgba(255,0,0,0.2)"
+        backgroundColor="#FFD4D2"
       />
     </div>
   );

--- a/stories/Hooks.stories.mdx
+++ b/stories/Hooks.stories.mdx
@@ -144,26 +144,3 @@ export const Component = () => {
 ```
 
 <Clear />
-
-#### Styling
-
-You can add styles to Dotting component via `React.CSSProperties` <br/>
-`gridStroke` props to control grid's appearances <br/>
-`background` props to control base layer's appearances <br/>
-
-```ts
-export const Component = () => {
-  return (
-    <div>
-      <Dotting
-        gridStrokeColor={gridStrokeColor}
-        gridStrokeWidth={gridStrokeWidth}
-        style={{ borderColor: "red" }}
-        backgroundColor="#FFD4D2"
-      />
-    </div>
-  );
-};
-```
-
-<GridStyling />

--- a/stories/Hooks.stories.mdx
+++ b/stories/Hooks.stories.mdx
@@ -150,7 +150,6 @@ export const Component = () => {
 You can add styles to Dotting component via `React.CSSProperties` <br/>
 `gridStroke` props to control grid's appearances <br/>
 `background` props to control base layer's appearances <br/>
-`backgroundMode` **checkerboard** is default you can use plain background if you change to **color** mode
 
 ```ts
 export const Component = () => {
@@ -160,9 +159,7 @@ export const Component = () => {
         gridStrokeColor={gridStrokeColor}
         gridStrokeWidth={gridStrokeWidth}
         style={{ borderColor: "red" }}
-        backgroundMode="color"
-        backgroundAlpha=0.2
-        backgroundColor="red"
+        backgroundColor="rgba(255,0,0,0.2)"
       />
     </div>
   );

--- a/stories/useDottingComponents/GridStyling.tsx
+++ b/stories/useDottingComponents/GridStyling.tsx
@@ -23,9 +23,7 @@ const GridStyling = () => {
         gridStrokeColor={gridStrokeColor}
         gridStrokeWidth={gridStrokeWidth}
         style={{ borderColor: "red" }}
-        backgroundMode="color"
-        backgroundAlpha={0.1}
-        backgroundColor="red"
+        backgroundColor="rgba(255, 0, 0, 0.2)"
       />
       <div
         style={{

--- a/stories/useDottingComponents/GridStyling.tsx
+++ b/stories/useDottingComponents/GridStyling.tsx
@@ -23,7 +23,7 @@ const GridStyling = () => {
         gridStrokeColor={gridStrokeColor}
         gridStrokeWidth={gridStrokeWidth}
         style={{ borderColor: "red" }}
-        backgroundColor="rgba(255, 0, 0, 0.2)"
+        backgroundColor="#FFD4D2"
       />
       <div
         style={{


### PR DESCRIPTION
🚀 [Related Issue: #55 #5]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

https://github.com/hunkim98/dotting/assets/57612141/4ea7a4b8-a896-4ca8-95bc-500c254f18a9


<br/>

### Changes

<!-- Name a title to your changes -->

## Change UI for extension buttons

- *[🎨Component] Change UI style for extension buttons*

  - Previously the extension button UI was visually unpleasing. It hampered the user experience of creating pixel art. Thus, I changed the whole extension button UI into a more visually pleasing UI. Now the button is nowhere to be seen, and users are presented with a simple UI that can be intuitively understood as extension buttons.

<br/>

## Mask extended/shrinked area during interaction

- *[🎨Component] Create Mask function for masking erased pixel canvas*

  - In the previous versions, while users extend/shrink the pixel canvas, they were able to see their pixel strokes even though the pixel canvas shrinked. This seemed awkward, and thus I created `renderCanvasMask` function to mask the pixels that should be erased.
  https://github.com/hunkim98/dotting/blob/ba33ad9e48e789ec1aea632fe151ebc7f0d5f1d2/src/components/Canvas/InteractionLayer.tsx#L1404-L1441


- *[🎨Component] Add props for `backgroundColor` and `DefaultPixelColor`*

  - To make the mask function to work, I needed the `backgroundColor` to be accessible in the Interaction Layer. Thus, I added `backgroundLayer` member variable in the interaction layer.

<br/>

## Modify `DottingProps`

- *[🎨Component] Remove `backgroundAlpha`, `backgroundMode` props*

  - Now with the `renderCanvasMask` function in the interaction layer, I found that if we allow users to control the backgroundAlpha, the mask function does not work correctly since the backgroundColor has an opacity less than 1. This inevitably resulted in the dataLayer strokes to be visible through the interaction layer. Thus, I decided to remove the `backgroundAlpha` props.
  - Interaction Layer's `renderCanvasMask` works by creating a rectangle square that covers the swiped pixels while the pixel canvas is shrinked. While this is feasible when `backgroundMode` is "color", it is not easy to mask the data layer when `backgroundMode` is "checkerBoard". Thus, I commented out the `setBackgroundMode` for now.

- *[🎨Component] Added `minScale`, `maxScale`, `defaultPixelColor`, `gridSquareLength`*

  - I added `minScale`, `maxScale` props for controlling scale range.
  - I also added `defaultPixelColor` for users who want to render a white background pixel canvas.
  - The `gridSquareLength` is now modifiable


- *[📒Docs] Update `Dotting` component stories.mdx*

  - Since there were some additions and removal of some props, I have duly updated the Dotting component stories.


<br/>

## Notes


<br/>

## Next Up?

