### PR TITLE
Fix: paint bucket

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -2001,7 +2001,6 @@ export default class Editor extends EventDispatcher {
         indicesQueue.enqueue({ rowIndex, columnIndex });
       });
     }
-    interactionLayer.resetCapturedData();
   }
 
   onMouseDown(evt: TouchyEvent) {

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -1506,7 +1506,7 @@ export default class Editor extends EventDispatcher {
       if (initialSelectedColor === this.brushColor) {
         return;
       }
-      this.paintSameColorRegion(initialSelectedColor, gridIndices, {
+      this.colorPixelsArea(initialSelectedColor, gridIndices, {
         rowIndex,
         columnIndex,
       });
@@ -1959,7 +1959,7 @@ export default class Editor extends EventDispatcher {
   }
 
   // this will be only used by the current device user
-  private paintSameColorRegion(
+  private colorPixelsArea(
     initialColor: string,
     gridIndices: Indices,
     currentIndices: { rowIndex: number; columnIndex: number },


### PR DESCRIPTION
🚀 [Related Issue: #60 ]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

https://github.com/hunkim98/dotting/assets/71599639/1e05839e-43e9-4c3d-a6bd-7137ee4aabe6


<br/>

### Changes

<!-- Name a title to your changes -->

## Write a title of your change

- _[🔗Other] Write a summary of what other things you have done_

  - Rename a function (-> `colorPixelsArea`)
  - Remove `interactionLayer.resetCapturedData();`
<br/>

## Notes

- I found that the data selected in interactionLayar was being initialized before the function ended.
- I thought it's okay to remove it, so I deleted it. 
- But is there any dependence on other parts that I didn't catch or understand? If you have, please leave comment. 
- "undo" and "redo" work well now.

<br />


