### PR TITLE
Ignore non-existent grid index delete

### DIFF
--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -420,6 +420,13 @@ export default class DataLayer extends BaseLayer {
 
   deleteRow(rowIndex: number) {
     let validRowIndex = null;
+    // This is to prevent deleting a non-existent row
+    if (!this.getData().has(rowIndex)) {
+      return {
+        swipedPixels: [],
+        validRowIndex,
+      };
+    }
     const swipedPixels = extractColoredPixelsFromRow(this.getData(), rowIndex);
     this.layers.forEach(layer => {
       validRowIndex = layer.deleteRowOfData(rowIndex);
@@ -429,6 +436,14 @@ export default class DataLayer extends BaseLayer {
 
   deleteColumn(columnIndex: number) {
     let validColumnIndex = null;
+    const firstRowKey = this.getData().keys().next().value;
+    // This is to prevent deleting a non-existent column
+    if (!this.getData().get(firstRowKey).has(columnIndex)) {
+      return {
+        swipedPixels: [],
+        validColumnIndex,
+      };
+    }
     const swipedPixels = extractColoredPixelsFromColumn(
       this.getData(),
       columnIndex,


### PR DESCRIPTION
🚀 [Related Issue: #67]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Fix delete error when deleting non-existent rowIndex or columnIndex

- _[🎨Component] Ignore delete operation for non-existent rowIndex or columnIndex_

  - I added a if condition statement in DataLayer to consider if the deleting rowIndex or columIndex is in the grid

<br/>

## Notes

- This feature is necessary for `collab-dotting`

  <br/>

## Next Up?

