### PR TITLE
Fix delta issues for select tool and clear action

### DIFF
--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -484,10 +484,10 @@ export default class DataLayer extends BaseLayer {
       data: Array<PixelModifyItem>;
     }> = [];
     this.layers.forEach(layer => {
-      const previousPixels = layer.clearData();
+      const { newPixels } = layer.clearData();
       clearedPixels.push({
         layerId: layer.getId(),
-        data: previousPixels,
+        data: newPixels,
       });
     });
     return clearedPixels;

--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -478,6 +478,21 @@ export default class DataLayer extends BaseLayer {
     return { validRowIndices, validColumnIndices };
   }
 
+  clear() {
+    const clearedPixels: Array<{
+      layerId: string;
+      data: Array<PixelModifyItem>;
+    }> = [];
+    this.layers.forEach(layer => {
+      const previousPixels = layer.clearData();
+      clearedPixels.push({
+        layerId: layer.getId(),
+        data: previousPixels,
+      });
+    });
+    return clearedPixels;
+  }
+
   deleteGridIndices({
     rowIndicesToDelete,
     columnIndicesToDelete,

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -2906,6 +2906,11 @@ export default class Editor extends EventDispatcher {
         isLocalChange: true,
         data: newData,
         layerId: this.dataLayer.getCurrentLayer().getId(),
+        delta: {
+          modifiedPixels: effectiveColorChangeItems,
+          addedOrDeletedColumns: [],
+          addedOrDeletedRows: [],
+        },
       });
     }
     this.interactionLayer.setSelectedArea(finalSelectedArea);

--- a/src/helpers/DottingDataLayer.ts
+++ b/src/helpers/DottingDataLayer.ts
@@ -108,6 +108,24 @@ export class DottingDataLayer extends Observable<DottingData> {
     return validColumnIndex;
   }
 
+  clearData() {
+    const previousPixels = [];
+    const rowKeys = Array.from(this.data.keys());
+    const columnKeys = Array.from(this.data.get(rowKeys[0])!.keys());
+    for (const i of rowKeys) {
+      for (const j of columnKeys) {
+        previousPixels.push({
+          rowIndex: i,
+          columnIndex: j,
+          color: this.data.get(i)!.get(j)!.color,
+        });
+        this.data.get(i)!.set(j, { color: "" });
+      }
+    }
+    this.notify(this.getCopiedData());
+    return previousPixels;
+  }
+
   getCopiedData = (): DottingData => {
     const copiedData = new Map();
     this.data.forEach((row, rowIndex) => {

--- a/src/helpers/DottingDataLayer.ts
+++ b/src/helpers/DottingDataLayer.ts
@@ -110,6 +110,7 @@ export class DottingDataLayer extends Observable<DottingData> {
 
   clearData() {
     const previousPixels = [];
+    const newPixels = [];
     const rowKeys = Array.from(this.data.keys());
     const columnKeys = Array.from(this.data.get(rowKeys[0])!.keys());
     for (const i of rowKeys) {
@@ -119,11 +120,16 @@ export class DottingDataLayer extends Observable<DottingData> {
           columnIndex: j,
           color: this.data.get(i)!.get(j)!.color,
         });
+        newPixels.push({
+          rowIndex: i,
+          columnIndex: j,
+          color: "",
+        });
         this.data.get(i)!.set(j, { color: "" });
       }
     }
     this.notify(this.getCopiedData());
-    return previousPixels;
+    return { previousPixels, newPixels };
   }
 
   getCopiedData = (): DottingData => {

--- a/stories/useHandlersComponents/DataChangeListener.tsx
+++ b/stories/useHandlersComponents/DataChangeListener.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
+import { useDotting } from "../../src";
 import {
   BrushTool,
   CanvasDataChangeHandler,
@@ -7,7 +8,6 @@ import {
 } from "../../src/components/Canvas/types";
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useHandlers from "../../src/hooks/useHandlers";
-import { useDotting } from "../../src";
 
 const DataChangeListener = () => {
   const ref = useRef<DottingRef>(null);
@@ -62,6 +62,8 @@ const DataChangeListener = () => {
         <div
           style={{
             padding: "10px 0",
+            display: "flex",
+            gap: 10,
           }}
         >
           <select
@@ -75,20 +77,17 @@ const DataChangeListener = () => {
             <option value={BrushTool.PAINT_BUCKET}>LINE</option>
             <option value={BrushTool.SELECT}>SELECT</option>
           </select>
+          <div style={{}}>
+            <button
+              onClick={() => {
+                clear();
+              }}
+            >
+              Clear
+            </button>
+          </div>
         </div>
-        <div
-          style={{
-            padding: "10px 0",
-          }}
-        >
-          <button
-            onClick={() => {
-              clear();
-            }}
-          >
-            Clear
-          </button>
-        </div>
+
         <strong>Data Delta</strong>
         {dataDelta && (
           <>

--- a/stories/useHandlersComponents/DataChangeListener.tsx
+++ b/stories/useHandlersComponents/DataChangeListener.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../src/components/Canvas/types";
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useHandlers from "../../src/hooks/useHandlers";
-import { useBrush } from "../../src";
+import { useDotting } from "../../src";
 
 const DataChangeListener = () => {
   const ref = useRef<DottingRef>(null);
@@ -15,6 +15,7 @@ const DataChangeListener = () => {
   const [selectedBrushTool, setSelectedBrushTool] = useState<BrushTool>(
     BrushTool.DOT,
   );
+  const { clear } = useDotting(ref);
 
   const [dataDelta, setDataDelta] = useState<CanvasDelta | null>(null);
 
@@ -74,6 +75,19 @@ const DataChangeListener = () => {
             <option value={BrushTool.PAINT_BUCKET}>LINE</option>
             <option value={BrushTool.SELECT}>SELECT</option>
           </select>
+        </div>
+        <div
+          style={{
+            padding: "10px 0",
+          }}
+        >
+          <button
+            onClick={() => {
+              clear();
+            }}
+          >
+            Clear
+          </button>
         </div>
         <strong>Data Delta</strong>
         {dataDelta && (

--- a/stories/useHandlersComponents/DataChangeListener.tsx
+++ b/stories/useHandlersComponents/DataChangeListener.tsx
@@ -1,15 +1,21 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import {
+  BrushTool,
   CanvasDataChangeHandler,
   CanvasDelta,
 } from "../../src/components/Canvas/types";
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useHandlers from "../../src/hooks/useHandlers";
+import { useBrush } from "../../src";
 
 const DataChangeListener = () => {
   const ref = useRef<DottingRef>(null);
   const { addDataChangeListener, removeDataChangeListener } = useHandlers(ref);
+  const [selectedBrushTool, setSelectedBrushTool] = useState<BrushTool>(
+    BrushTool.DOT,
+  );
+
   const [dataDelta, setDataDelta] = useState<CanvasDelta | null>(null);
 
   const handlDataChangeHandler: CanvasDataChangeHandler = ({
@@ -37,7 +43,12 @@ const DataChangeListener = () => {
         fontFamily: `'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif`,
       }}
     >
-      <Dotting ref={ref} width={"100%"} height={300} />
+      <Dotting
+        ref={ref}
+        width={"100%"}
+        height={300}
+        brushTool={selectedBrushTool}
+      />
       <div
         style={{
           marginTop: 25,
@@ -47,6 +58,23 @@ const DataChangeListener = () => {
           marginBottom: 50,
         }}
       >
+        <div
+          style={{
+            padding: "10px 0",
+          }}
+        >
+          <select
+            value={selectedBrushTool}
+            onChange={e => {
+              setSelectedBrushTool(e.target.value as BrushTool);
+            }}
+          >
+            <option value={BrushTool.DOT}>DOT</option>
+            <option value={BrushTool.ERASER}>ERASER</option>
+            <option value={BrushTool.PAINT_BUCKET}>LINE</option>
+            <option value={BrushTool.SELECT}>SELECT</option>
+          </select>
+        </div>
         <strong>Data Delta</strong>
         {dataDelta && (
           <>


### PR DESCRIPTION
🚀 [Related Issue: #70]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Allow select tool to emit delta in `DataChangeHandler`

- _[🎨Component] Add logic for emitting delta in DataChangeHandler_

  - Previously, there was not delta emitted from select tool actions (extending, moving)
  - Now, the modified pixels delta is emitted in the DataChangeHandler

- _[📒Docs] Add tools in the DataChangeHandler storybook component_

  - To allow testing of delta with other tools, I have added a `<select>` for choosing the desired tool


## Allow `clear()` to emit delta information in `DataChangeHandler`

- _[🎨Component] Add logic in `clear` callback to emit delta data_

  - The `clear` callback did not emit any delta information
  - Since clear erases all data in all layers, I emitted the data change event for every layer, allowing users to notice that all layers are being cleared

<br/>

## Notes

  <br/>

## Next Up?

