### PR TITLE
Fix touch issues for pinchzoom and extension

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -2682,8 +2682,10 @@ export default class Editor extends EventDispatcher {
       }
       const buttonDirection = this.detectButtonClicked(mouseCartCoord);
       if (buttonDirection) {
-        this.gridLayer.setHoveredButton(buttonDirection);
-        this.renderGridLayer();
+        if (!this.interactionLayer.getCapturedData()) {
+          this.gridLayer.setHoveredButton(buttonDirection);
+          this.renderGridLayer();
+        }
         return;
       } else {
         if (this.mouseMode !== MouseMode.EXTENDING) {

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -1541,7 +1541,7 @@ export default class Editor extends EventDispatcher {
 
   // we should allow panning with pinch zoom too
   handlePinchZoom = (evt: TouchyEvent) => {
-    if (!this.isPanZoomable) {
+    if (!this.isPanZoomable || this.interactionLayer.getCapturedData()) {
       return;
     }
     // const lastMousePos = this.panPoint.lastMousePos;
@@ -2419,7 +2419,7 @@ export default class Editor extends EventDispatcher {
     } else {
       const touchesCount =
         evt.touches && evt.touches.length ? evt.touches.length : 0;
-      if (pixelIndex && this.brushTool !== BrushTool.NONE && touchesCount < 1) {
+      if (pixelIndex && this.brushTool !== BrushTool.NONE && touchesCount < 2) {
         this.drawPixelInInteractionLayer(
           pixelIndex.rowIndex,
           pixelIndex.columnIndex,

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -359,6 +359,7 @@ export default class Editor extends EventDispatcher {
     if (isPanZoomable !== undefined) {
       this.isPanZoomable = isPanZoomable;
     }
+    console.log(this.isPanZoomable);
   }
 
   setIsDrawingEnabled(isDrawingEnabled: boolean) {
@@ -1539,7 +1540,7 @@ export default class Editor extends EventDispatcher {
     }
   }
 
-  handlePinchZoom(evt: TouchyEvent) {
+  handlePinchZoom = (evt: TouchyEvent) => {
     if (!this.isPanZoomable) {
       return;
     }
@@ -1556,7 +1557,7 @@ export default class Editor extends EventDispatcher {
       this.pinchZoomDiff = newPanZoom.pinchZoomDiff;
       this.setPanZoom(newPanZoom.panZoom);
     }
-  }
+  };
 
   handleKeyDown = (e: KeyboardEvent) => {
     if (e.code === "KeyZ" && (e.ctrlKey || e.metaKey)) {


### PR DESCRIPTION
🚀 [Related Issue: #57 #8]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Enable pinch zoom with touch

- _[🎨Component] Fix handlePinchZoom to be activated when two fingers are on the canvas_

  - Previously, pinch and zooming with two fingers did not work.
  - The problem was that the `this.isPanzoomable` inside function `handlePinchzoom` was pointing to the function not the class variable

- _[🔗Other] Allow pinch zoom to be called when there are two fingers on the canvas_

  - Previously, if user was drawing in the canvas, even though the user uses two fingers to pinch and zoom, pinch zoom did not happen.
  - I fixed the code to change to pinch zoom mode even though the user was drawing in the canvas

## Fix hovered button when user is extending the area

- _[🎨Component] Fix hovered extension button to the initially clicked button when user drags the button_

  - Previously, the hovered button kept changing according to the user's mouse position
  - I fixed the hovered button to the initial hovered button to reduce confusion while user extends the grids


<br/>

## Notes

  <br/>

## Next Up?


