### PR TITLE
Feature: Create callback `setLayers` for setting multiple layers in Dottng

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,7 +12,14 @@ export const parameters = {
   options: {
     storySort: {
       // Introduction will be shown first
-      order: ["Introduction", "Customization", "Components", "Hooks", "Hooks/Setup"],
+      order: [
+        "Introduction",
+        "Customization",
+        "Components",
+        "Hooks",
+        "Hooks/Setup",
+        "Hooks/useDotting",
+      ],
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotting",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "main": "build/index.js",
   "module": "build/index.esm.js",
   "files": [

--- a/src/components/Canvas/DataLayer.tsx
+++ b/src/components/Canvas/DataLayer.tsx
@@ -250,6 +250,18 @@ export default class DataLayer extends BaseLayer {
     }
   }
 
+  // this is for setting all layers together
+  setLayers(layers: Array<LayerProps>) {
+    this.layers = [];
+    this.layers = layers.map(
+      layer =>
+        new DottingDataLayer({
+          data: layer.data,
+          id: layer.id,
+        }),
+    );
+  }
+
   setGridSquareLength(length: number) {
     this.gridSquareLength = length;
   }

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -52,6 +52,7 @@ import {
   getInBetweenPixelIndicesfromCoords,
   getRowCountFromData,
   getRowKeysFromData,
+  validateLayers,
   validateSquareArray,
 } from "../../utils/data";
 import EventDispatcher from "../../utils/eventDispatcher";
@@ -663,7 +664,7 @@ export default class Editor extends EventDispatcher {
     return this.dataLayer.getLayers().map(layer => {
       return {
         id: layer.getId(),
-        data: layer.getDataArray()
+        data: layer.getDataArray(),
       };
     });
   }
@@ -875,6 +876,17 @@ export default class Editor extends EventDispatcher {
       },
     });
     this.renderAll();
+  }
+
+  setLayers(layers: Array<LayerProps>) {
+    try {
+      validateLayers(layers);
+      // reset history when set layer is called
+      this.undoHistory = [];
+      this.redoHistory = [];
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   setPanZoom({

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -890,6 +890,36 @@ export default class Editor extends EventDispatcher {
     // reset history when set layer is called
     this.undoHistory = [];
     this.redoHistory = [];
+    this.dataLayer.setCurrentLayer(layers[0].id);
+    this.gridLayer.setCriterionDataForRendering(this.dataLayer.getData());
+    const rowCount = this.dataLayer.getRowCount();
+    const columnCount = this.dataLayer.getColumnCount();
+    this.gridLayer.setRowCount(rowCount);
+    this.gridLayer.setColumnCount(columnCount);
+    this.interactionLayer.setDataLayerRowCount(rowCount);
+    this.interactionLayer.setDataLayerColumnCount(columnCount);
+    this.emitDataChangeEvent({
+      isLocalChange: false,
+      data: this.dataLayer.getCopiedData(),
+      layerId: this.dataLayer.getCurrentLayer().getId(),
+    });
+    this.emitGridChangeEvent({
+      dimensions: this.dataLayer.getDimensions(),
+      indices: this.dataLayer.getGridIndices(),
+    });
+    this.interactionLayer.setCriterionDataForRendering(
+      this.dataLayer.getData(),
+    );
+    this.dataLayer.setCriterionDataForRendering(this.dataLayer.getData());
+    this.interactionLayer.resetCapturedData();
+    this.setPanZoom({
+      offset: {
+        x: -this.panZoom.scale * (columnCount / 2) * this.gridSquareLength,
+        y: -this.panZoom.scale * (rowCount / 2) * this.gridSquareLength,
+      },
+    });
+    this.emitCurrentLayerStatus();
+    this.renderAll();
   }
 
   setPanZoom({

--- a/src/hooks/useDotting.ts
+++ b/src/hooks/useDotting.ts
@@ -4,6 +4,7 @@ import {
   AddGridIndicesParams,
   DeleteGridIndicesParams,
   ImageDownloadOptions,
+  LayerProps,
   PixelModifyItem,
 } from "../components/Canvas/types";
 import { DottingRef } from "../components/Dotting";
@@ -56,6 +57,13 @@ const useDotting = (ref: MutableRefObject<DottingRef | null>) => {
     [ref],
   );
 
+  const setLayers = useCallback(
+    (layers: Array<LayerProps>) => {
+      ref.current?.setLayers(layers);
+    },
+    [ref],
+  );
+
   const addGridIndices = useCallback(
     (params: AddGridIndicesParams) => {
       ref.current?.addGridIndices(params);
@@ -79,6 +87,7 @@ const useDotting = (ref: MutableRefObject<DottingRef | null>) => {
     undo,
     redo,
     setData,
+    setLayers,
     addGridIndices,
     deleteGridIndices,
   };

--- a/src/hooks/useLayers.ts
+++ b/src/hooks/useLayers.ts
@@ -4,13 +4,14 @@ import useHandlers from "./useHandlers";
 import {
   LayerChangeParams,
   LayerDataForHook,
+  LayerProps,
   PixelModifyItem,
 } from "../components/Canvas/types";
 import { DottingRef } from "../components/Dotting";
 
 const useLayers = (ref: MutableRefObject<DottingRef | null>) => {
   const [currentLayer, setCurrentLayerHook] = useState<LayerDataForHook>();
-  const [layers, setLayers] = useState<Array<LayerDataForHook>>([]);
+  const [layersInfo, setLayersInfo] = useState<Array<LayerDataForHook>>([]);
 
   const { addLayerChangeEventListener, removeLayerChangeEventListener } =
     useHandlers(ref);
@@ -22,7 +23,7 @@ const useLayers = (ref: MutableRefObject<DottingRef | null>) => {
         data: currentLayer.getDataArray(),
         isVisible: currentLayer.getIsVisible(),
       });
-      setLayers(
+      setLayersInfo(
         layers.map(layer => ({
           id: layer.getId(),
           data: layer.getDataArray(),
@@ -100,9 +101,16 @@ const useLayers = (ref: MutableRefObject<DottingRef | null>) => {
     [ref],
   );
 
+  const setLayers = useCallback(
+    (layers: Array<LayerProps>) => {
+      ref.current?.setLayers(layers);
+    },
+    [ref],
+  );
+
   return {
     currentLayer,
-    layers,
+    layers: layersInfo,
     addLayer,
     removeLayer,
     changeLayerPosition,

--- a/src/hooks/useLayers.ts
+++ b/src/hooks/useLayers.ts
@@ -4,7 +4,6 @@ import useHandlers from "./useHandlers";
 import {
   LayerChangeParams,
   LayerDataForHook,
-  LayerProps,
   PixelModifyItem,
 } from "../components/Canvas/types";
 import { DottingRef } from "../components/Dotting";

--- a/src/hooks/useLayers.ts
+++ b/src/hooks/useLayers.ts
@@ -101,13 +101,6 @@ const useLayers = (ref: MutableRefObject<DottingRef | null>) => {
     [ref],
   );
 
-  const setLayers = useCallback(
-    (layers: Array<LayerProps>) => {
-      ref.current?.setLayers(layers);
-    },
-    [ref],
-  );
-
   return {
     currentLayer,
     layers: layersInfo,

--- a/src/test/Editor/set.data.test.tsx
+++ b/src/test/Editor/set.data.test.tsx
@@ -1,0 +1,46 @@
+import { CreateEmptySquareData } from "../../../stories/utils/dataCreator";
+import Editor from "../../components/Canvas/Editor";
+
+describe("test set data", () => {
+  let editor: Editor;
+  let canvasElement: HTMLCanvasElement;
+  beforeEach(() => {
+    const divElement = document.createElement("div");
+    const interactionCanvas = divElement.appendChild(
+      document.createElement("canvas"),
+    );
+    const gridCanvas = divElement.appendChild(document.createElement("canvas"));
+    const dataCanvas = divElement.appendChild(document.createElement("canvas"));
+    const backgroundCanvas = divElement.appendChild(
+      document.createElement("canvas"),
+    );
+    const mockEditor = new Editor({
+      gridCanvas,
+      interactionCanvas,
+      dataCanvas,
+      backgroundCanvas,
+    });
+    divElement.tabIndex = 1;
+    divElement.onmousedown = () => {
+      divElement.focus();
+    };
+    divElement.addEventListener("keydown", (e: any) => {
+      editor.onKeyDown(e);
+    });
+
+    mockEditor.setSize(800, 800);
+    editor = mockEditor;
+    // initialize the canvas with select tool selecting all the pixels
+    canvasElement = editor.getCanvasElement();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("set data with correct data", () => {
+    editor.setData(CreateEmptySquareData(15));
+    expect(editor.getRowCount()).toBe(15);
+    expect(editor.getColumnCount()).toBe(15);
+  });
+});

--- a/src/test/Editor/set.data.test.tsx
+++ b/src/test/Editor/set.data.test.tsx
@@ -1,5 +1,11 @@
 import { CreateEmptySquareData } from "../../../stories/utils/dataCreator";
 import Editor from "../../components/Canvas/Editor";
+import {
+  InvalidDataDimensionsError,
+  InvalidDataIndicesError,
+  LayerNotFoundError,
+  UnspecifiedLayerIdError,
+} from "../../utils/error";
 
 describe("test set data", () => {
   let editor: Editor;
@@ -42,5 +48,189 @@ describe("test set data", () => {
     editor.setData(CreateEmptySquareData(15));
     expect(editor.getRowCount()).toBe(15);
     expect(editor.getColumnCount()).toBe(15);
+  });
+
+  it("set data when there are multiple layers", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer2",
+        data: CreateEmptySquareData(15),
+      },
+    ];
+    editor.setLayers(newLayers);
+    try {
+      editor.setData(CreateEmptySquareData(15));
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnspecifiedLayerIdError);
+    }
+  });
+
+  it("set data with wrong dimensions when there are other layers already", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer2",
+        data: CreateEmptySquareData(15),
+      },
+    ];
+    editor.setLayers(newLayers);
+    try {
+      editor.setData(CreateEmptySquareData(16), "layer2");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidDataDimensionsError);
+    }
+  });
+
+  it("set data with non existent layer id", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer2",
+        data: CreateEmptySquareData(15),
+      },
+    ];
+    editor.setLayers(newLayers);
+    try {
+      editor.setData(CreateEmptySquareData(15), "layer3");
+    } catch (error) {
+      expect(error).toBeInstanceOf(LayerNotFoundError);
+    }
+  });
+
+  it("set data with wrong indices", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: [
+          [
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 2,
+            },
+          ],
+          [
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 2,
+            },
+          ],
+        ],
+      },
+      {
+        id: "layer2",
+        data: [
+          [
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 2,
+            },
+          ],
+          [
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 2,
+            },
+          ],
+        ],
+      },
+    ];
+    editor.setLayers(newLayers);
+    try {
+      editor.setData(
+        [
+          [
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 2,
+            },
+          ],
+          [
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 2,
+            },
+          ],
+        ],
+        "layer2",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidDataIndicesError);
+    }
   });
 });

--- a/src/test/Editor/set.layers.test.tsx
+++ b/src/test/Editor/set.layers.test.tsx
@@ -1,0 +1,117 @@
+import { CreateEmptySquareData } from "../../../stories/utils/dataCreator";
+import Editor from "../../components/Canvas/Editor";
+import {
+  DuplicateLayerIdError,
+  InvalidDataDimensionsError,
+} from "../../utils/error";
+
+describe("test set layers", () => {
+  let editor: Editor;
+  let canvasElement: HTMLCanvasElement;
+  beforeEach(() => {
+    const divElement = document.createElement("div");
+    const interactionCanvas = divElement.appendChild(
+      document.createElement("canvas"),
+    );
+    const gridCanvas = divElement.appendChild(document.createElement("canvas"));
+    const dataCanvas = divElement.appendChild(document.createElement("canvas"));
+    const backgroundCanvas = divElement.appendChild(
+      document.createElement("canvas"),
+    );
+    const mockEditor = new Editor({
+      gridCanvas,
+      interactionCanvas,
+      dataCanvas,
+      backgroundCanvas,
+    });
+    divElement.tabIndex = 1;
+    divElement.onmousedown = () => {
+      divElement.focus();
+    };
+    divElement.addEventListener("keydown", (e: any) => {
+      editor.onKeyDown(e);
+    });
+
+    mockEditor.setSize(800, 800);
+    editor = mockEditor;
+    // initialize the canvas with select tool selecting all the pixels
+    canvasElement = editor.getCanvasElement();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("set layers with correct configuration", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer2",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer3",
+        data: CreateEmptySquareData(15),
+      },
+    ];
+    editor.setLayers(newLayers);
+    const layers = editor.getLayersAsArray();
+    expect(layers.length).toEqual(3);
+    expect(layers[0].id).toEqual("layer1");
+    expect(layers[0].data.length).toEqual(15);
+    expect(layers[0].data[0].length).toEqual(15);
+    expect(layers[1].id).toEqual("layer2");
+    expect(layers[1].data.length).toEqual(15);
+    expect(layers[1].data[0].length).toEqual(15);
+    expect(layers[2].id).toEqual("layer3");
+    expect(layers[2].data.length).toEqual(15);
+    expect(layers[2].data[0].length).toEqual(15);
+  });
+
+  it("set layers with duplicate id", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer1",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer3",
+        data: CreateEmptySquareData(15),
+      },
+    ];
+    try {
+      editor.setLayers(newLayers);
+    } catch (error) {
+      expect(error).toBeInstanceOf(DuplicateLayerIdError);
+    }
+  });
+
+  it("set layers with different data dimensions", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: CreateEmptySquareData(15),
+      },
+      {
+        id: "layer2",
+        data: CreateEmptySquareData(20),
+      },
+      {
+        id: "layer3",
+        data: CreateEmptySquareData(15),
+      },
+    ];
+    try {
+      editor.setLayers(newLayers);
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidDataDimensionsError);
+    }
+  });
+});

--- a/src/test/Editor/set.layers.test.tsx
+++ b/src/test/Editor/set.layers.test.tsx
@@ -3,6 +3,8 @@ import Editor from "../../components/Canvas/Editor";
 import {
   DuplicateLayerIdError,
   InvalidDataDimensionsError,
+  InvalidDataIndicesError,
+  InvalidSquareDataError,
 } from "../../utils/error";
 
 describe("test set layers", () => {
@@ -112,6 +114,177 @@ describe("test set layers", () => {
       editor.setLayers(newLayers);
     } catch (error) {
       expect(error).toBeInstanceOf(InvalidDataDimensionsError);
+    }
+  });
+
+  it("set layers with wrong indices", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: [
+          [
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 2,
+            },
+          ],
+          [
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 2,
+            },
+          ],
+        ],
+      },
+      {
+        id: "layer2",
+        data: [
+          [
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 2,
+            },
+          ],
+          [
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 2,
+            },
+          ],
+        ],
+      },
+    ];
+    try {
+      editor.setLayers(newLayers);
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidDataIndicesError);
+    }
+  });
+
+  it("set layers with wrong square data", () => {
+    const newLayers = [
+      {
+        id: "layer1",
+        data: [
+          [
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 1,
+            },
+          ],
+          [
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 0,
+              columnIndex: 2,
+            },
+          ],
+        ],
+      },
+      {
+        id: "layer2",
+        data: [
+          [
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 1,
+              columnIndex: 2,
+            },
+          ],
+          [
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 0,
+            },
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 1,
+            },
+            {
+              color: "red",
+              rowIndex: 2,
+              columnIndex: 2,
+            },
+          ],
+        ],
+      },
+    ];
+    try {
+      editor.setLayers(newLayers);
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidSquareDataError);
     }
   });
 });

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,3 +1,9 @@
+import {
+  DuplicateLayerIdError,
+  InvalidDataDimensionsError,
+  InvalidDataIndicesError,
+  InvalidSquareDataError,
+} from "./error";
 import { getBressenhamIndices } from "./math";
 import { getPixelIndexFromMouseCartCoord } from "./position";
 import {
@@ -274,9 +280,7 @@ export const validateLayers = (layers: Array<LayerProps>) => {
   // 3) all data should have same topRowIndex and leftColumnIndex
   layers.forEach(layer => {
     if (layerIdSet.has(layer.id)) {
-      throw new Error(
-        `Duplicate layer id ${layer.id}. Please make sure all layer ids are unique.`,
-      );
+      throw new DuplicateLayerIdError(layer.id);
     }
     layerIdSet.add(layer.id);
     const { isDataValid, columnCount, rowCount } = validateSquareArray(
@@ -287,9 +291,7 @@ export const validateLayers = (layers: Array<LayerProps>) => {
         measuredColumnCount !== columnCount ||
         measuredRowCount !== rowCount
       ) {
-        throw new Error(
-          `Invalid data for layer ${layer.id}. Please check the data.`,
-        );
+        throw new InvalidDataDimensionsError(layer.id);
       }
     } else {
       measuredColumnCount = columnCount;
@@ -297,9 +299,7 @@ export const validateLayers = (layers: Array<LayerProps>) => {
     }
 
     if (!isDataValid) {
-      throw new Error(
-        `Invalid data for layer ${layer.id}. Please check the data.`,
-      );
+      throw new InvalidSquareDataError(layer.id);
     }
     if (measuredLeftColumnIndex == null || measuredTopRowIndex == null) {
       measuredLeftColumnIndex = layer.data[0][0].columnIndex;
@@ -308,14 +308,10 @@ export const validateLayers = (layers: Array<LayerProps>) => {
     const topRowIndex = layer.data[0][0].rowIndex;
     const leftColumnIndex = layer.data[0][0].columnIndex;
     if (topRowIndex !== measuredTopRowIndex) {
-      throw new Error(
-        `Invalid data for layer ${layer.id}. Please check the data.`,
-      );
+      throw new InvalidDataIndicesError(layer.id);
     }
     if (leftColumnIndex !== measuredLeftColumnIndex) {
-      throw new Error(
-        `Invalid data for layer ${layer.id}. Please check the data.`,
-      );
+      throw new InvalidDataIndicesError(layer.id);
     }
   });
   return true;

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -5,6 +5,7 @@ import {
   GridIndices,
   PixelModifyItem,
   Coord,
+  LayerProps,
 } from "../components/Canvas/types";
 
 export const getGridIndicesFromData = (data: DottingData): GridIndices => {
@@ -251,4 +252,71 @@ export const getInBetweenPixelIndicesfromCoords = (
       }
     }
   }
+};
+
+export const validateLayers = (layers: Array<LayerProps>) => {
+  if (!layers) {
+    throw new Error("No layer provided");
+  }
+  if (layers.length === 0) {
+    throw new Error(
+      "initLayers should not be empty. Please provide at least one layer.",
+    );
+  }
+  const layerIdSet: Set<string> = new Set();
+  let measuredColumnCount = null;
+  let measuredRowCount = null;
+  let measuredTopRowIndex = null;
+  let measuredLeftColumnIndex = null;
+  // all init data passed initially, should be
+  // 1) a square array
+  // 2) all data should have same row and column count
+  // 3) all data should have same topRowIndex and leftColumnIndex
+  layers.forEach(layer => {
+    if (layerIdSet.has(layer.id)) {
+      throw new Error(
+        `Duplicate layer id ${layer.id}. Please make sure all layer ids are unique.`,
+      );
+    }
+    layerIdSet.add(layer.id);
+    const { isDataValid, columnCount, rowCount } = validateSquareArray(
+      layer.data,
+    );
+    if (measuredColumnCount !== null && measuredRowCount !== null) {
+      if (
+        measuredColumnCount !== columnCount ||
+        measuredRowCount !== rowCount
+      ) {
+        throw new Error(
+          `Invalid data for layer ${layer.id}. Please check the data.`,
+        );
+      }
+    } else {
+      measuredColumnCount = columnCount;
+      measuredRowCount = rowCount;
+    }
+
+    if (!isDataValid) {
+      throw new Error(
+        `Invalid data for layer ${layer.id}. Please check the data.`,
+      );
+    }
+    if (measuredLeftColumnIndex == null || measuredTopRowIndex == null) {
+      measuredLeftColumnIndex = layer.data[0][0].columnIndex;
+      measuredTopRowIndex = layer.data[0][0].rowIndex;
+    }
+    const topRowIndex = layer.data[0][0].rowIndex;
+    const leftColumnIndex = layer.data[0][0].columnIndex;
+    if (topRowIndex !== measuredTopRowIndex) {
+      throw new Error(
+        `Invalid data for layer ${layer.id}. Please check the data.`,
+      );
+    }
+    if (leftColumnIndex !== measuredLeftColumnIndex) {
+      throw new Error(
+        `Invalid data for layer ${layer.id}. Please check the data.`,
+      );
+    }
+  });
+  return true;
 };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,66 @@
+export class DottingError extends Error {
+  name = "DottingError";
+  constructor(message) {
+    super(message);
+  }
+}
+
+export class DuplicateLayerIdError extends DottingError {
+  name = "DuplicateLayerIdError";
+  constructor(layerId) {
+    super(
+      `Duplicate layer id ${layerId}. Please make sure all layer ids are unique.`,
+    );
+  }
+}
+
+export class InvalidSquareDataError extends DottingError {
+  name = "InvalidSquareDataError";
+  constructor(layerId?: string) {
+    const message = layerId ? ` for layer ${layerId}` : "";
+    super(
+      `Invalid square data${message}. Please make sure all data have the same row and column count.`,
+    );
+  }
+}
+
+export class InvalidDataDimensionsError extends DottingError {
+  name = "InvalidDataDimensionsError";
+  constructor(layerId?: string) {
+    const message = layerId ? ` for layer ${layerId}` : "";
+    super(
+      `Invalid data dimensions${message}. Please make sure all data have the same dimensions.`,
+    );
+  }
+}
+
+export class InvalidDataIndicesError extends DottingError {
+  name = "InvalidDataIndicesError";
+  constructor(layerId?: string) {
+    const message = layerId ? ` for layer ${layerId}` : "";
+    super(
+      `Invalid data indices${message}. Please make sure all data have the same topRowIndex and leftColumnIndex.`,
+    );
+  }
+}
+
+export class UnspecifiedLayerIdError extends DottingError {
+  name = "UnspecifiedLayerIdError";
+  constructor() {
+    super(`Layer id has not been specified`);
+  }
+}
+
+export class InvalidLayerIdError extends DottingError {
+  name = "InvalidLayerIdError";
+  constructor(layerId) {
+    super(`Invalid layer id ${layerId}.`);
+  }
+}
+
+export class LayerNotFoundError extends DottingError {
+  name = "LayerNotFoundError";
+  constructor(layerId) {
+    super(`Layer ${layerId} not found.`);
+  }
+}

--- a/stories/useDotting.stories.mdx
+++ b/stories/useDotting.stories.mdx
@@ -16,6 +16,7 @@ import {
   UndoRedo,
   SetData,
   GridChange,
+  SetLayers,
 } from "./useDottingComponents";
 
 <Meta title="Hooks/useDotting" />
@@ -424,6 +425,12 @@ With `undo` and `redo` methods, you can undo and redo the last action.
 With `setData`, you can set the data of the pixel canvas. (The 2d array should be a square array)
 
 <SetData />
+
+#### 8. SetLayers Example `setLayers(data: Array<LayerProps>)`
+
+With `setLayers`, you can set the layers of the pixel canvas. (The 2d array should be a square array)
+
+<SetLayers />
 
 <div className="subheading">Example Source Codes</div>
 

--- a/stories/useDotting.stories.mdx
+++ b/stories/useDotting.stories.mdx
@@ -213,7 +213,7 @@ td input:focus {
 
 With `useDotting`, you can manipulate the grids.
 
-#### Features provided by `useDotting`
+#### Callbacks provided by `useDotting`
 
 <table>
   <thead>
@@ -229,42 +229,41 @@ With `useDotting`, you can manipulate the grids.
   </thead>
   <tbody>
     <tr>
-      <td>`downloadImage(options?: ImageDownloadOptions)`</td>
+      <td>`downloadImage`</td>
       <td>Allows you to download the pixel image</td>
       <td>
-        `ImageDownloadOptions`
-        ```ts
-        export interface ImageDownloadOptions {
-          isGridVisible?: boolean;
-        }
-        ```
+        `ImageDownloadOptions` For more information about the parameters, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section1");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 1</u>.
       </td>
     </tr>
     <tr>
-      <td>`clear()`</td>
+      <td>`clear`</td>
       <td>Allows you to clear the canvas</td>
       <td></td>
     </tr>
     <tr>
-      <td>`colorPixels(data: Array<PixelModifyItem>)`</td>
+      <td>`colorPixels`</td>
       <td>
         Allows you to color pixels on specific indices. If the index provided is 
         not in the grid, the grid first extends its grid and then colors it
       </td>
       <td>
-        `Array<PixelModifyItem>`
-        `PixelModifyItem` is defined as follows:
-        ```ts
-        export interface PixelModifyItem {
-          rowIndex: number;
-          columnIndex: number;
-          color: string;
-        }
-        ```
+        `Array<PixelModifyItem>`. For more information about the type, please refer to 
+        <u onClick={() => {
+          const el = document.getElementById("section2");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 2</u>.
       </td>
     </tr>
     <tr>
-      <td>`erasePixels(data: Array<{rowIndex: number; columnIndex: number}>)`</td>
+      <td>`erasePixels`</td>
       <td>
         Allows you to erase pixels on specific indices. If the index provided is
         not in the grid, that data is ignored
@@ -272,60 +271,93 @@ With `useDotting`, you can manipulate the grids.
       <td>`Array<{rowIndex: number; columnIndex: number}>`</td>
     </tr>
     <tr>
-      <td>`setIndicatorPixels(indicators: Array<PixelModifyItem>)`</td>
+      <td>`setIndicatorPixels`</td>
       <td>
         Allows you to set the indicator pixels. If the index provided is not in
         the grid, that data is ignored
       </td>
-      <td>`Array<PixelModifyItem>`</td>
+      <td>
+        `Array<PixelModifyItem>` For more information about the type, please refer to  
+        <u onClick={() => {
+          const el = document.getElementById("section5");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 5</u>.
+      </td>
     </tr>
     <tr>
-      <td>`undo()`</td>
+      <td>`undo`</td>
       <td>
         Allows you to undo the last action
       </td>
       <td></td>
     </tr>
     <tr>
-      <td>`redo()`</td>
+      <td>`redo`</td>
       <td>
         Allows you to redo the last action
       </td>
       <td></td>
     </tr>
     <tr>
-      <td>`setData(data: Array<Array<PixelModifyItem>>)`</td>
+      <td>`setData`</td>
       <td>
         Allows you to set the data of the pixel canvas. (The 2d array should be a square array)
       </td>
       <td>
-        `Array<PixelModifyItem>`
-        `PixelModifyItem` is defined as follows:
-        ```ts
-        export interface PixelModifyItem {
-          rowIndex: number;
-          columnIndex: number;
-          color: string;
-        }
-        ```
+        `Array<PixelModifyItem>` For more information about the type, please refer to 
+        <u onClick={() => {
+          const el = document.getElementById("section7");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 7</u>.
       </td>
     </tr>
     <tr>
-      <td>`addGridIndices(params: AddGridIndicesParams)`</td>
+      <td>`addGridIndices`</td>
       <td>
         Allows you to add grid indices to the grid.
       </td>
       <td>
-        `AddGridIndicesParams`. For more information about the type, please refer to section 3.
+        `AddGridIndicesParams`. For more information about the type, please refer to 
+        <u onClick={() => {
+          const el = document.getElementById("section3");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 3</u>.
       </td>
     </tr>
     <tr>
-      <td>`deleteGridIndices(params: DeleteGridIndicesParams)`</td>
+      <td>`deleteGridIndices`</td>
       <td>
         Allows you to delete grid indices to the grid.
       </td>
       <td>
-        `DeleteGridIndicesParams`. For more information about the type, please refer to section 3.
+        `DeleteGridIndicesParams`. For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section3");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 3</u>.
+      </td>
+    </tr>
+    <tr>
+    <td>`setLayers`</td>
+      <td>
+        Allows you to set layers. You must provide an array of `LayerProps` to this method.
+      </td>
+      <td>
+        `Array<LayerProps>`. For more information about the type, Please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section8");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 8</u>.
       </td>
     </tr>
 
@@ -334,15 +366,24 @@ With `useDotting`, you can manipulate the grids.
 
 ### Examples
 
-#### 1. Download Image Example `downloadImage()`
+<div id="section1"></div>
+#### 1. Download Image Example `downloadImage`
 
-With `downloadImage` method, you can download the image of the grid.
+With `downloadImage(options?: ImageDownloadOptions)` method, you can download the image of the grid. The parameter that you can pass to the callback is `ImageDownloadOptions`.
+The `ImageDownloadOptions` type is defined as follows:
+
+```ts
+export interface ImageDownloadOptions {
+  isGridVisible?: boolean;
+}
+```
 
 <DownloadImage />
 
-#### 2. Change Pixel Color Example `colorPixels(data: PixelModifyData)`, `erasePixels(data: Array<{rowIndex: number; columnIndex: number}>)`
+<div id="section2"></div>
+#### 2. Change Pixel Color Example `colorPixels`, `erasePixels`
 
-With `colorPixels` method, you can change the color of specific pixels.
+With `colorPixels(data: PixelModifyData)` method, you can change the color of specific pixels.
 The `PixelModifyData` type is defined as follows:
 
 ```ts
@@ -359,15 +400,16 @@ By passing an array of `PixelModifyItem` you are able to color the pixels.
 If the rowIndex and columnIndex of the pixel is not in the grid, the grid
 first extends its grid and then colors it.
 
-You can also erase pixels using `erasePixels` method. The `erasePixels` method
+You can also erase pixels using `erasePixels` method. The `erasePixels(data: Array<{rowIndex: number; columnIndex: number}>)` method
 takes an array of `{rowIndex: number; columnIndex: number}` as a parameter. If the rowIndex and
 columnIndex of the pixel is not in the grid, that data is ignored.
 
 <ColorPixels />
 
-#### 3. Grid Change Example `addGridIndices(params: AddGridIndicesParams)`, `deleteGridIndices(params: DeleteGridIndicesParams)`
+<div id="section3"></div>
+#### 3. Grid Change Example `addGridIndices`,`deleteGridIndices`
 
-With `addGridIndices` method, you can add grid indices to the grid.
+With `addGridIndices(params: AddGridIndicesParams)` method, you can add grid indices to the grid.
 The `AddGridIndicesParams` type is defined as follows:
 
 ```ts
@@ -382,7 +424,7 @@ export type AddGridIndicesParams = {
 
 By passing an array of `rowIndices` and `columnIndices` you are able to add grid indices to the grid.
 
-With `deleteGridIndices` method, you can delete grid indices to the grid.
+With `deleteGridIndices(params: DeleteGridIndicesParams)` method, you can delete grid indices to the grid.
 The `DeleteGridIndicesParams` type is defined as follows:
 
 ```ts
@@ -396,15 +438,17 @@ export type DeleteGridIndicesParams = {
 
 <GridChange />
 
-#### 4. Clear Example `clear()`
+<div id="section4"></div>
+#### 4. Clear Example `clear`
 
-With `clear` method, you can clear all the pixels in the grid.
+With `clear()` method, you can clear all the pixels in the grid.
 
 <Clear />
 
-#### 5. Set Indicator Pixels `setIndicatorPixels(data: Array<PixelModifyItem>)`
+<div id="section5"></div>
+#### 5. Set Indicator Pixels `setIndicatorPixels`
 
-With `setIndicatorPixels` method, you can set the indicator pixels. The indicator pixels are
+With `setIndicatorPixels(data: Array<PixelModifyItem>)` method, you can set the indicator pixels. The indicator pixels are
 the pixels that are shwon as indicators in the grid. Their opacity is lower than the real pixel data.
 They do not affect the data of the grid.
 
@@ -412,23 +456,66 @@ By the way, if you want to initially have the indicator pixels before the canvas
 you need to pass the `initIndicatorData` prop to the `Dotting` component.
 The data type of the `initIndicatorData` is the `Array<PixelModifyItem>`.
 
+PixelModifyItem is defined as follows:
+
+```ts
+export interface PixelModifyItem {
+  rowIndex: number;
+  columnIndex: number;
+  color: string;
+}
+```
+
 <SetIndicatorPixels />
 
-#### 6. Undo and Redo Example `undo()`, `redo()`
+<div id="section6"></div>
+#### 6. Undo and Redo Example `undo`, `redo`
 
-With `undo` and `redo` methods, you can undo and redo the last action.
+With `undo()` and `redo()` methods, you can undo and redo the last action.
 
 <UndoRedo />
 
-#### 7. SetData Example `setData(data: Array<Array<PixelModifyItem>>)`
+<div id="section7"></div>
+#### 7. SetData Example `setData`
 
-With `setData`, you can set the data of the pixel canvas. (The 2d array should be a square array)
+With `setData(data: Array<Array<PixelModifyItem>>)`, you can set the data of the pixel canvas. You must pass a 2d array of `PixelModifyItem` to this method.
+The type of `PixelModifyItem` is defined as follows:
+
+```ts
+export interface PixelModifyItem {
+  rowIndex: number;
+  columnIndex: number;
+  color: string;
+}
+```
+
+The 2d array should be a square array.
 
 <SetData />
 
-#### 8. SetLayers Example `setLayers(data: Array<LayerProps>)`
+<div id="section8"></div>
+#### 8. SetLayers Example `setLayers`
 
-With `setLayers`, you can set the layers of the pixel canvas. (The 2d array should be a square array)
+With `setLayers(data: Array<LayerProps>)`, you can set the layers of the pixel canvas. You must pass an array of `LayerProps` to this method.
+The `LayerProps` type is defined as follows:
+
+```ts
+export interface LayerProps {
+  id: string;
+  data: Array<Array<PixelModifyItem>>;
+}
+```
+
+By passing an array of `LayerProps` you are able to set the layers of the pixel canvas.
+The type of `PixelModifyItem` is defined as follows:
+
+```ts
+export interface PixelModifyItem {
+  rowIndex: number;
+  columnIndex: number;
+  color: string;
+}
+```
 
 <SetLayers />
 

--- a/stories/useDotting.stories.mdx
+++ b/stories/useDotting.stories.mdx
@@ -211,7 +211,8 @@ td input:focus {
 
 # `useDotting`
 
-With `useDotting`, you can manipulate the grids.
+With `useDotting`, you can manipulate the `Dotting` canvas directly.
+You can color pixels, change grid size, set data, and so on.
 
 #### Callbacks provided by `useDotting`
 
@@ -277,7 +278,7 @@ With `useDotting`, you can manipulate the grids.
         the grid, that data is ignored
       </td>
       <td>
-        `Array<PixelModifyItem>` For more information about the type, please refer to  
+        `Array<PixelModifyItem>` For more information about the type, please refer to
         <u onClick={() => {
           const el = document.getElementById("section5");
           if (el) {

--- a/stories/useDottingComponents/SetData.tsx
+++ b/stories/useDottingComponents/SetData.tsx
@@ -25,6 +25,7 @@ const SetData = () => {
             display: "flex",
             justifyContent: "center",
             alignItems: "center",
+            marginBottom: 50,
             gap: 5,
           }}
         >

--- a/stories/useDottingComponents/SetLayers.tsx
+++ b/stories/useDottingComponents/SetLayers.tsx
@@ -1,6 +1,6 @@
 import React, { BaseSyntheticEvent, useRef, useState } from "react";
 
-import { useBrush } from "../../src";
+import { useBrush, useDotting } from "../../src";
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useLayers from "../../src/hooks/useLayers";
 import { CreateEmptySquareData } from "../utils/dataCreator";
@@ -10,17 +10,16 @@ const SetLayers = () => {
   const { changeBrushColor } = useBrush(ref);
   const {
     layers,
-    addLayer,
     removeLayer,
     changeLayerPosition,
     currentLayer,
     setCurrentLayer,
     reorderLayersByIds,
   } = useLayers(ref);
+  const { setLayers } = useDotting(ref);
   const [draggingSectionId, setDraggingSectionId] = useState(null);
   const draggingItemIndex = useRef<number | null>(null);
   const draggingOverItemIndex = useRef<number | null>(null);
-  const [createdLayerCount, setCreatedLayerCount] = useState(3);
 
   const onDragStart = (e: BaseSyntheticEvent, index: number, id: string) => {
     draggingItemIndex.current = index;
@@ -129,14 +128,6 @@ const SetLayers = () => {
               </div>
             </li>
           ))}
-          <button
-            onClick={() => {
-              addLayer("layer" + (createdLayerCount + 1), layers.length);
-              setCreatedLayerCount(createdLayerCount + 1);
-            }}
-          >
-            Add Layer
-          </button>
         </ul>
       </div>
 
@@ -167,6 +158,7 @@ const SetLayers = () => {
             },
           ]}
         />
+
         <div>
           {[
             "#FF0000",
@@ -191,6 +183,44 @@ const SetLayers = () => {
               }}
             />
           ))}
+        </div>
+        <div>
+          <button
+            style={{
+              padding: "5px 10px",
+              background: "none",
+            }}
+            onClick={() => {
+              setLayers([
+                {
+                  id: "layer1",
+                  data: CreateEmptySquareData(15),
+                },
+              ]);
+            }}
+          >
+            Set Single Layer
+          </button>
+          <button
+            style={{
+              padding: "5px 10px",
+              background: "none",
+            }}
+            onClick={() => {
+              setLayers([
+                {
+                  id: "layer1",
+                  data: CreateEmptySquareData(15),
+                },
+                {
+                  id: "layer2",
+                  data: CreateEmptySquareData(15),
+                },
+              ]);
+            }}
+          >
+            Set Two Layers
+          </button>
         </div>
       </div>
     </div>

--- a/stories/useDottingComponents/SetLayers.tsx
+++ b/stories/useDottingComponents/SetLayers.tsx
@@ -1,0 +1,200 @@
+import React, { BaseSyntheticEvent, useRef, useState } from "react";
+
+import { useBrush } from "../../src";
+import Dotting, { DottingRef } from "../../src/components/Dotting";
+import useLayers from "../../src/hooks/useLayers";
+import { CreateEmptySquareData } from "../utils/dataCreator";
+
+const SetLayers = () => {
+  const ref = useRef<DottingRef>(null);
+  const { changeBrushColor } = useBrush(ref);
+  const {
+    layers,
+    addLayer,
+    removeLayer,
+    changeLayerPosition,
+    currentLayer,
+    setCurrentLayer,
+    reorderLayersByIds,
+  } = useLayers(ref);
+  const [draggingSectionId, setDraggingSectionId] = useState(null);
+  const draggingItemIndex = useRef<number | null>(null);
+  const draggingOverItemIndex = useRef<number | null>(null);
+  const [createdLayerCount, setCreatedLayerCount] = useState(3);
+
+  const onDragStart = (e: BaseSyntheticEvent, index: number, id: string) => {
+    draggingItemIndex.current = index;
+    setDraggingSectionId(id);
+  };
+
+  const onAvailableItemDragEnter = (e: BaseSyntheticEvent, index: number) => {
+    draggingOverItemIndex.current = index;
+    const copyListItems = [...layers];
+    const draggingItemContent = copyListItems[draggingItemIndex.current!];
+    copyListItems.splice(draggingItemIndex.current!, 1);
+    copyListItems.splice(
+      draggingOverItemIndex.current!,
+      0,
+      draggingItemContent,
+    );
+    draggingItemIndex.current = draggingOverItemIndex.current;
+    draggingOverItemIndex.current = null;
+    changeLayerPosition(draggingItemContent.id, index);
+  };
+
+  const onDragEnd = (e: BaseSyntheticEvent) => {
+    reorderLayersByIds(layers.map(layer => layer.id));
+    setDraggingSectionId(null);
+  };
+
+  const onDragOver = e => {
+    e.preventDefault();
+  };
+
+  const onClickHandler = (e: BaseSyntheticEvent, id: string) => {
+    e.stopPropagation();
+    setCurrentLayer(id);
+  };
+  return (
+    <div
+      style={{
+        marginTop: 20,
+        width: "100%",
+        display: "flex",
+        fontFamily: `'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif`,
+        marginBottom: 50,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          paddingRight: 10,
+          maxWidth: 150,
+        }}
+      >
+        <div style={{ fontSize: 18, marginBottom: 5 }}>Layers</div>
+        <div style={{ fontSize: 12, marginBottom: 5 }}>
+          Drag and Drop the layers to move their positions
+        </div>
+        <ul
+          style={{
+            width: "100%",
+            height: 440,
+            overflowY: "scroll",
+            overflow: "auto",
+            display: "flex",
+            gap: 5,
+            flexDirection: "column",
+            listStyleType: "none",
+            padding: 0,
+            margin: 0,
+          }}
+        >
+          {layers.map((layer, index) => (
+            <li
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                listStyle: "none",
+                textAlign: "center",
+                border: "1px solid black",
+                padding: 5,
+                gap: 5,
+                backgroundColor:
+                  currentLayer.id === layer.id ? "grey" : "white",
+                color: currentLayer.id === layer.id ? "white" : "black",
+                cursor: "pointer",
+
+                opacity: draggingSectionId === layer.id ? 0.5 : 1,
+              }}
+              key={layer.id}
+              onClick={e => onClickHandler(e, layer.id)}
+              onDragStart={e => onDragStart(e, index, layer.id)}
+              onDragEnter={e => onAvailableItemDragEnter(e, index)}
+              onDragEnd={onDragEnd}
+              onDragOver={onDragOver}
+              draggable
+            >
+              <div>{layer.id}</div>
+              <div>
+                <button
+                  onClick={e => {
+                    e.stopPropagation();
+                    removeLayer(layer.id);
+                  }}
+                >
+                  remove
+                </button>
+              </div>
+            </li>
+          ))}
+          <button
+            onClick={() => {
+              addLayer("layer" + (createdLayerCount + 1), layers.length);
+              setCreatedLayerCount(createdLayerCount + 1);
+            }}
+          >
+            Add Layer
+          </button>
+        </ul>
+      </div>
+
+      <div
+        style={{
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <Dotting
+          ref={ref}
+          width={"100%"}
+          height={500}
+          initLayers={[
+            {
+              id: "layer1",
+              data: CreateEmptySquareData(15),
+            },
+            {
+              id: "layer2",
+              data: CreateEmptySquareData(15),
+            },
+            {
+              id: "layer3",
+              data: CreateEmptySquareData(15),
+            },
+          ]}
+        />
+        <div>
+          {[
+            "#FF0000",
+            "#0000FF",
+            "#00FF00",
+            "#FF00FF",
+            "#00FFFF",
+            "#FFFF00",
+            "#000000",
+            "#FFFFFF",
+          ].map(color => (
+            <div
+              key={color}
+              onClick={changeBrushColor.bind(null, color)}
+              style={{
+                width: 25,
+                height: 25,
+                margin: 10,
+                border: "1px solid black",
+                backgroundColor: color,
+                display: "inline-block",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SetLayers;

--- a/stories/useDottingComponents/index.ts
+++ b/stories/useDottingComponents/index.ts
@@ -6,6 +6,7 @@ import GridStyling from "./GridStyling";
 import SetData from "./SetData";
 import SetIndicatorPixels from "./SetIndicatorPixels";
 import UndoRedo from "./UndoRedo";
+import SetLayers from "./SetLayers";
 
 export {
   Clear,
@@ -15,5 +16,6 @@ export {
   GridStyling,
   UndoRedo,
   SetData,
+  SetLayers,
   GridChange,
 };

--- a/stories/useDottingComponents/index.ts
+++ b/stories/useDottingComponents/index.ts
@@ -5,8 +5,8 @@ import GridChange from "./GridChange";
 import GridStyling from "./GridStyling";
 import SetData from "./SetData";
 import SetIndicatorPixels from "./SetIndicatorPixels";
-import UndoRedo from "./UndoRedo";
 import SetLayers from "./SetLayers";
+import UndoRedo from "./UndoRedo";
 
 export {
   Clear,


### PR DESCRIPTION
🚀 [Related Issue: #74 ]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

https://github.com/hunkim98/dotting/assets/57612141/455fcae0-6ae8-4a3e-ac5b-7755d30ab81d



<br/>

### Changes

<!-- Name a title to your changes -->

## Add `setLayers` callback in Dotting

- _[🪝Hooks] Added `setLayers` callback in `useDotting` hook_

  - Now users can use `setLayers` through importing `useDotting` hook

- _[🎨Component] Add `setLayers` in both `Editor.tsx` and `DataLayer.tsx`_

  - To enable setting layers with callback I created `setLayers` callback in both `Editor.tsx` and `DataLayer.tsx`
  - The validation of the passed props happens in the `Editor.tsx`
  - I also added some test codes for both `setLayers` callback and `setData` callback

- _[📒Docs] Update `setLayers` callback in `useDotting` storybook_

  - Users are able to test the `setLayers` callback in section 8.

- _[🔗Other] Add error class for ease of testing_

  - To test the validation of passed layers and data, I created a file in `utils` folder named `error.ts`
  - We can use this error class to test if error are correctly thrown through jest.

<br/>

## Notes

- This feature is necessary if a developer is planning to initialize the `dotting` canvas with saved layers information!

  <br/>

## Next Up?

