### PR TITLE
Feature: Allow pixel canvas download as SVG

### DIFF
--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -23,6 +23,7 @@ export type PixelData = {
 
 export interface ImageDownloadOptions {
   isGridVisible?: boolean;
+  type: "png" | "svg";
 }
 
 export type DottingData = Map<number, Map<number, PixelData>>;

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -62,7 +62,7 @@ export interface DottingRef {
   clear: () => void;
   colorPixels: (data: Array<PixelModifyItem>) => void;
   erasePixels: (data: Array<{ rowIndex: number; columnIndex: number }>) => void;
-  downloadImage: (options?: ImageDownloadOptions) => void;
+  downloadImage: (options: ImageDownloadOptions) => void;
   setIndicatorPixels: (data: Array<PixelModifyItem>) => void;
   undo: () => void;
   redo: () => void;

--- a/src/hooks/useDotting.ts
+++ b/src/hooks/useDotting.ts
@@ -29,7 +29,7 @@ const useDotting = (ref: MutableRefObject<DottingRef | null>) => {
   );
 
   const downloadImage = useCallback(
-    (options?: ImageDownloadOptions) => {
+    (options: ImageDownloadOptions) => {
       ref.current?.downloadImage(options);
     },
     [ref],

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -71,3 +71,10 @@ export class UnrecognizedDownloadOptionError extends DottingError {
     super(`Unrecognized download option.`);
   }
 }
+
+export class NoDataToMakeSvgError extends DottingError {
+  name = "NoDataToMakeSvgError";
+  constructor() {
+    super(`No data to make svg.`);
+  }
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -64,3 +64,10 @@ export class LayerNotFoundError extends DottingError {
     super(`Layer ${layerId} not found.`);
   }
 }
+
+export class UnrecognizedDownloadOptionError extends DottingError {
+  name = "UnrecognizedDownloadOptionError";
+  constructor() {
+    super(`Unrecognized download option.`);
+  }
+}

--- a/stories/useDotting.stories.mdx
+++ b/stories/useDotting.stories.mdx
@@ -375,6 +375,7 @@ The `ImageDownloadOptions` type is defined as follows:
 
 ```ts
 export interface ImageDownloadOptions {
+  type: "png" | "svg";
   isGridVisible?: boolean;
 }
 ```

--- a/stories/useDottingComponents/DownloadImage.tsx
+++ b/stories/useDottingComponents/DownloadImage.tsx
@@ -20,12 +20,30 @@ const DownloadImage = () => {
         style={{
           padding: "5px 10px",
           background: "none",
+          marginTop: 15,
+        }}
+        onClick={() =>
+          downloadImage({
+            type: "png",
+          })
+        }
+      >
+        Download as PNG
+      </button>
+      <button
+        style={{
+          padding: "5px 10px",
+          background: "none",
           marginTop: 10,
           marginBottom: 50,
         }}
-        onClick={() => downloadImage()}
+        onClick={() =>
+          downloadImage({
+            type: "svg",
+          })
+        }
       >
-        Download
+        Download as SVG
       </button>
     </div>
   );


### PR DESCRIPTION
🚀 [Resolves #68]

### Preview

https://github.com/hunkim98/dotting/assets/57612141/4c4d7ab8-e1af-4303-9fd1-87196dd1e9be

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Allow download as SVG

- _[🪝Hooks] Change `useDotting` hook's download function to have option for 'png' or 'svg'_

  - To allow user's to download image as 'svg' or 'png', I changed the download function param to have an option value.
  - A user needs to specify their preferred download type. ex) `downloadImage({option: 'svg'})`

- _[🎨Component] Modify download image function to consider svg_

  - I updated some functions to enable downloading in svg

- _[📒Docs] Add 'svg' download option to original Download example_

  - Now users can download image in an 'svg' format

<br/>

## Notes

  <br/>

## Next Up?
