### PR TITLE
Feature: Implement canvas info change handler for future purposes (creating foreground canvas layer for users to manipulate)

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -247,6 +247,44 @@ export default class Editor extends EventDispatcher {
     });
   }
 
+  emitCurrentCanvasInfoStatus(baseColumnCount?: number, baseRowCount?: number) {
+    const leftTopPoint: Coord = {
+      x: 0,
+      y: 0,
+    };
+    const convertedLeftTopScreenPoint = convertCartesianToScreen(
+      this.element,
+      leftTopPoint,
+      this.dpr,
+    );
+    const correctedLeftTopScreenPoint = getScreenPoint(
+      convertedLeftTopScreenPoint,
+      this.panZoom,
+    );
+    const gridSquareSize = this.gridSquareLength * this.panZoom.scale;
+    const columnCount = baseColumnCount
+      ? baseColumnCount
+      : this.dataLayer.getColumnCount();
+    const rowCount = baseRowCount ? baseRowCount : this.dataLayer.getRowCount();
+    this.emitCanvasInfoChangeEvent({
+      panZoom: this.panZoom,
+      topLeftCornerOffset: correctedLeftTopScreenPoint,
+      topRightCornerOffset: {
+        x: correctedLeftTopScreenPoint.x + columnCount * gridSquareSize,
+        y: correctedLeftTopScreenPoint.y,
+      },
+      bottomLeftCornerOffset: {
+        x: correctedLeftTopScreenPoint.x,
+        y: correctedLeftTopScreenPoint.y + rowCount * gridSquareSize,
+      },
+      bottomRightCornerOffset: {
+        x: correctedLeftTopScreenPoint.x + columnCount * gridSquareSize,
+        y: correctedLeftTopScreenPoint.y + rowCount * gridSquareSize,
+      },
+      gridSquareSize,
+    });
+  }
+
   emitCanvasInfoChangeEvent(parmas: CanvasInfoChangeParams) {
     this.emit(CanvasEvents.CANVAS_INFO_CHANGE, parmas);
   }
@@ -875,6 +913,7 @@ export default class Editor extends EventDispatcher {
       dimensions: this.dataLayer.getDimensions(),
       indices: this.dataLayer.getGridIndices(),
     });
+    this.emitCurrentCanvasInfoStatus();
     this.interactionLayer.setCriterionDataForRendering(
       this.dataLayer.getData(),
     );
@@ -914,6 +953,7 @@ export default class Editor extends EventDispatcher {
       dimensions: this.dataLayer.getDimensions(),
       indices: this.dataLayer.getGridIndices(),
     });
+    this.emitCurrentCanvasInfoStatus();
     this.interactionLayer.setCriterionDataForRendering(
       this.dataLayer.getData(),
     );
@@ -990,41 +1030,7 @@ export default class Editor extends EventDispatcher {
     this.relayPanZoomToOtherLayers();
     // we must render all when panzoom changes!
     this.renderAll();
-    const leftTopPoint: Coord = {
-      x: 0,
-      y: 0,
-    };
-    const convertedLeftTopScreenPoint = convertCartesianToScreen(
-      this.element,
-      leftTopPoint,
-      this.dpr,
-    );
-    const correctedLeftTopScreenPoint = getScreenPoint(
-      convertedLeftTopScreenPoint,
-      this.panZoom,
-    );
-    const gridSquareSize = this.gridSquareLength * this.panZoom.scale;
-    this.emitCanvasInfoChangeEvent({
-      panZoom: this.panZoom,
-      gridCount: {
-        rowCount: rowCount,
-        columnCount: columnCount,
-      },
-      gridSquareSize: gridSquareSize,
-      topLeftCornerOffset: correctedLeftTopScreenPoint,
-      topRightCornerOffset: {
-        x: correctedLeftTopScreenPoint.x + gridSquareSize * columnCount,
-        y: correctedLeftTopScreenPoint.y,
-      },
-      bottomLeftCornerOffset: {
-        x: correctedLeftTopScreenPoint.x,
-        y: correctedLeftTopScreenPoint.y + gridSquareSize * rowCount,
-      },
-      bottomRightCornerOffset: {
-        x: correctedLeftTopScreenPoint.x + gridSquareSize * columnCount,
-        y: correctedLeftTopScreenPoint.y + gridSquareSize * rowCount,
-      },
-    });
+    this.emitCurrentCanvasInfoStatus(baseColumnCount, baseRowCount);
   }
 
   relayPanZoomToOtherLayers() {
@@ -1227,6 +1233,7 @@ export default class Editor extends EventDispatcher {
         dimensions: updatedDimensions,
         indices: updatedGridIndices,
       });
+      this.emitCurrentCanvasInfoStatus();
     }
     this.relayDataDimensionsToLayers();
     this.dataLayer.setCriterionDataForRendering(this.dataLayer.getData());
@@ -1302,6 +1309,7 @@ export default class Editor extends EventDispatcher {
         dimensions: updatedDimensions,
         indices: updatedGridIndices,
       });
+      this.emitCurrentCanvasInfoStatus();
     }
     this.relayDataDimensionsToLayers();
     this.dataLayer.setCriterionDataForRendering(this.dataLayer.getData());
@@ -1994,6 +2002,7 @@ export default class Editor extends EventDispatcher {
           dimensions: updatedDimensions,
           indices: updatedGridIndices,
         });
+        this.emitCurrentCanvasInfoStatus();
       }
 
       // deletes the records of the current user

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -127,6 +127,18 @@ export type LayerChangeParams = {
 
 export type LayerChangeHandler = (params: LayerChangeParams) => void;
 
+export type CanvasInfoChangeParams = {
+  panZoom: PanZoom;
+  dimensions: Dimensions;
+  topLeftCornerOffset: Coord;
+  topRightCornerOffset: Coord;
+  bottomLeftCornerOffset: Coord;
+  bottomRightCornerOffset: Coord;
+  gridSize: number;
+};
+
+export type CanvasInfoChangeHandler = (params: CanvasInfoChangeParams) => void;
+
 export type GridIndices = {
   topRowIndex: number;
   bottomRowIndex: number;

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -130,10 +130,6 @@ export type LayerChangeHandler = (params: LayerChangeParams) => void;
 
 export type CanvasInfoChangeParams = {
   panZoom: PanZoom;
-  gridCount: {
-    rowCount: number;
-    columnCount: number;
-  };
   topLeftCornerOffset: Coord;
   topRightCornerOffset: Coord;
   bottomLeftCornerOffset: Coord;

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -45,6 +45,7 @@ export enum CanvasEvents {
   BRUSH_CHANGE = "brushChange",
   HOVER_PIXEL_CHANGE = "hoverPixelChange",
   LAYER_CHANGE = "layerChange",
+  CANVAS_INFO_CHANGE = "canvasInfoChange",
 }
 
 export enum BrushTool {
@@ -129,12 +130,15 @@ export type LayerChangeHandler = (params: LayerChangeParams) => void;
 
 export type CanvasInfoChangeParams = {
   panZoom: PanZoom;
-  dimensions: Dimensions;
+  gridCount: {
+    rowCount: number;
+    columnCount: number;
+  };
   topLeftCornerOffset: Coord;
   topRightCornerOffset: Coord;
   bottomLeftCornerOffset: Coord;
   bottomRightCornerOffset: Coord;
-  gridSize: number;
+  gridSquareSize: number;
 };
 
 export type CanvasInfoChangeHandler = (params: CanvasInfoChangeParams) => void;

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -18,6 +18,7 @@ import {
   CanvasEvents,
   CanvasGridChangeHandler,
   CanvasHoverPixelChangeHandler,
+  CanvasInfoChangeHandler,
   CanvasStrokeEndHandler,
   DeleteGridIndicesParams,
   DottingData,
@@ -116,6 +117,10 @@ export interface DottingRef {
   ) => void;
   addLayerChangeEventListener: (listener: LayerChangeHandler) => void;
   removeLayerChangeEventListener: (listener: LayerChangeHandler) => void;
+  addCanvasInfoChangeEventListener: (listener: CanvasInfoChangeHandler) => void;
+  removeCanvasInfoChangeEventListener: (
+    listener: CanvasInfoChangeHandler,
+  ) => void;
   // for canvas element event listeners
   addCanvasElementEventListener: (
     type: string,
@@ -163,6 +168,9 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
   >([]);
   const [layerChangeListeners, setLayerChangeListeners] = useState<
     LayerChangeHandler[]
+  >([]);
+  const [canvasInfoChangeListeners, setCanvasInfoChangeListeners] = useState<
+    CanvasInfoChangeHandler[]
   >([]);
 
   const [canvasElementEventListeners, setCanvasElementEventListeners] =
@@ -333,6 +341,21 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       });
     };
   }, [editor, layerChangeListeners]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+    canvasInfoChangeListeners.forEach(listener => {
+      editor.addEventListener(CanvasEvents.CANVAS_INFO_CHANGE, listener);
+    });
+    editor.emitCurrentCanvasInfoStatus();
+    return () => {
+      canvasInfoChangeListeners.forEach(listener => {
+        editor?.removeEventListener(CanvasEvents.CANVAS_INFO_CHANGE, listener);
+      });
+    };
+  }, [editor, canvasInfoChangeListeners]);
 
   // The below is to add event listeners directly to the canvas element
   // E.g. for mousemove, mousedown, mouseup, etc.
@@ -555,6 +578,23 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     (listener: CanvasHoverPixelChangeHandler) => {
       editor.removeEventListener(CanvasEvents.HOVER_PIXEL_CHANGE, listener);
       setHoverPixelChangeListeners(listeners =>
+        listeners.filter(l => l !== listener),
+      );
+    },
+    [editor],
+  );
+
+  const addCanvasInfoChangeEventListener = useCallback(
+    (listener: CanvasInfoChangeHandler) => {
+      setCanvasInfoChangeListeners(listeners => [...listeners, listener]);
+    },
+    [],
+  );
+
+  const removeCanvasInfoChangeEventListener = useCallback(
+    (listener: CanvasInfoChangeHandler) => {
+      editor.removeEventListener(CanvasEvents.CANVAS_INFO_CHANGE, listener);
+      setCanvasInfoChangeListeners(listeners =>
         listeners.filter(l => l !== listener),
       );
     },
@@ -847,6 +887,8 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       removeHoverPixelChangeListener,
       addLayerChangeEventListener,
       removeLayerChangeEventListener,
+      addCanvasInfoChangeEventListener,
+      removeCanvasInfoChangeEventListener,
       // for canvas element listener
       addCanvasElementEventListener,
       removeCanvasElementEventListener,
@@ -892,6 +934,8 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       removeHoverPixelChangeListener,
       addLayerChangeEventListener,
       removeLayerChangeEventListener,
+      addCanvasInfoChangeEventListener,
+      removeCanvasInfoChangeEventListener,
       // for canvas element listener
       addCanvasElementEventListener,
       removeCanvasElementEventListener,

--- a/src/hooks/useHandlers.ts
+++ b/src/hooks/useHandlers.ts
@@ -5,6 +5,7 @@ import {
   CanvasDataChangeHandler,
   CanvasGridChangeHandler,
   CanvasHoverPixelChangeHandler,
+  CanvasInfoChangeHandler,
   CanvasStrokeEndHandler,
   LayerChangeHandler,
 } from "../components/Canvas/types";
@@ -95,6 +96,20 @@ const useHandlers = (ref: MutableRefObject<DottingRef | null>) => {
     [ref],
   );
 
+  const addCanvasInfoChangeEventListener = useCallback(
+    (listener: CanvasInfoChangeHandler) => {
+      ref.current?.addCanvasInfoChangeEventListener(listener);
+    },
+    [ref],
+  );
+
+  const removeCanvasInfoChangeEventListener = useCallback(
+    (listener: CanvasInfoChangeHandler) => {
+      ref.current?.removeCanvasInfoChangeEventListener(listener);
+    },
+    [ref],
+  );
+
   const addCanvasElementEventListener = useCallback(
     (event: string, listener: EventListenerOrEventListenerObject) => {
       ref.current?.addCanvasElementEventListener(event, listener);
@@ -122,6 +137,8 @@ const useHandlers = (ref: MutableRefObject<DottingRef | null>) => {
     removeHoverPixelChangeListener,
     addLayerChangeEventListener,
     removeLayerChangeEventListener,
+    addCanvasInfoChangeEventListener,
+    removeCanvasInfoChangeEventListener,
     // Below are for canvas element listener
     addCanvasElementEventListener,
     removeCanvasElementEventListener,

--- a/stories/useHandlers.stories.mdx
+++ b/stories/useHandlers.stories.mdx
@@ -13,6 +13,7 @@ import {
   HoverPixelListener,
   CanvasElementEvents,
   DataChangeListener,
+  CanvasInfoChangeListener,
 } from "./useHandlersComponents";
 
 <Meta title="Hooks/useHandlers" />
@@ -232,185 +233,198 @@ The events that you can listen to are:
   </thead>
   <tbody>
     <tr>
-      <td>`addDataChangeListener(listener: CanvasDataChangeHandler)`</td>
+      <td>`addDataChangeListener`</td>
       <td>
         Allows you to listen to data change events. This event is triggered when the user draws on the canvas.
         The `delta` parameter tells you the exact changes that happened on the canvas.
       </td>
       <td> 
-        `CanvasDataChangeHandler`
-        ```ts
-        export type CanvasDataChangeParams = {
-          isLocalChange: boolean;
-          data: DottingData;
-          layerId: string;
-          delta?: CanvasDelta;
-        };
-        export type CanvasDataChangeHandler = (params: CanvasDataChangeParams) => void;
-        export type DottingData = Map<number, Map<number, PixelData>>;
-        export type PixelData = {
-            color: string;
-        };
-        epxort type CanvasDelta = {
-          modifiedPixels: Array<PixelModifyItem>;
-            addedOrDeletedRows?: Array<{
-              isDelete: boolean;
-              index: number;
-            }>;
-            addedOrDeletedColumns?: Array<{
-              isDelete: boolean;
-              index: number;
-            }>;
-        }
-        ```
+        `CanvasDataChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section1");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 1</u>.
       </td>
     </tr>
     <tr>
-      <td>`removeDataChangeListener(listener: CanvasDataChangeHandler)`</td>
+      <td>`removeDataChangeListener`</td>
       <td>
         Allows you to remove a data change listener
       </td>
-      <td>`CanvasDataChangeHandler`</td>
+      <td>`CanvasDataChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section1");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 1</u>.</td>
     </tr>
     <tr>
-      <td>`addGridChangeListener(listener: CanvasGridChangeHandler)`</td>
+      <td>`addGridChangeListener`</td>
       <td>
         Allows you to the listen to grid change events.
       </td>
       <td>
-        `CanvasGridChangeHandler`
-        ```ts
-        export type CanvasGridChangeParams = {
-          dimensions: {
-            columnCount: number;
-            rowCount: number;
-          };
-          indices: {
-            topRowIndex: number;
-            bottomRowIndex: number;
-            leftColumnIndex: number;
-            rightColumnIndex: number;
-          };
-        };
-
-        export type CanvasGridChangeHandler = (params: CanvasGridChangeParams) => void;
-        ```
+        `CanvasGridChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section2");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 2</u>.
       </td>
     </tr>
     <tr>
-      <td>`removeGridChangeListener(listener: CanvasGridChangeHandler)`</td>
+      <td>`removeGridChangeListener`</td>
       <td>
         Allows you to remove a grid change listener
       </td>
-      <td>`CanvasGridChangeHandler`</td>
+      <td>`CanvasGridChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section2");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 2</u>.</td>
     </tr>
     <tr>
-      <td>`addBrushChangeListener(listener: CanvasBrushChangeHandler)`</td>
+      <td>`addBrushChangeListener`</td>
       <td>
         Allows you to listen to brush change events
       </td>
       <td>
-        `CanvasBrushChangeHandler`
-        ```ts
-        export type CanvasBrushChangeParams = {
-          brushColor: string;
-          brushTool: BrushTool;
-        };
-
-        export type CanvasBrushChangeHandler = (
-          params: CanvasBrushChangeParams,
-        ) => void;
-
-        export enum BrushTool {
-          DOT = "DOT",
-          ERASER = "ERASER",
-          PAINT_BUCKET = "PAINT_BUCKET",
-          SELECT = "SELECT",
-        }
-        ```
+        `CanvasBrushChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section3");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 3</u>.
       </td>
     </tr>
     <tr>
-      <td>`removeBrushChangeListener(listener: CanvasBrushChangeHandler)`</td>
+      <td>`removeBrushChangeListener`</td>
       <td>
         Allows you to remove a brush change listener
       </td>
-      <td>`CanvasBrushChangeHandler`</td>
+      <td>`CanvasBrushChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section3");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 3</u>.</td>
     </tr>
     <tr>
-      <td>`addStrokeEndListener(listener: CanvasStrokeEndHandler)`</td>
+      <td>`addStrokeEndListener`</td>
       <td>
         Allows you to add a listener to stroke end events
       </td>
       <td>
-        `CanvasStrokeEndHandler`
-        ```ts
-
-        export type CanvasStrokeEndParams = {
-          strokedPixels: Array<ColorChangeItem>;
-          data: DottingData;
-          strokeTool: BrushTool;
-        };
-
-        export type CanvasStrokeEndHandler = (params: CanvasStrokeEndParams) => void;
-
-        export interface ColorChangeItem {
-            rowIndex: number;
-            columnIndex: number;
-            color: string;
-            previousColor: string;
-        }
-        export type DottingData = Map<number, Map<number, PixelData>>;
-        export type PixelData = {
-            color: string;
-        };
-        ```
+        `CanvasStrokeEndHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section4");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 4</u>.
       </td>
     </tr>
     <tr>
-      <td>`removeStrokeEndListener(listener: CanvasStrokeEndHandler)`</td>
+      <td>`removeStrokeEndListener`</td>
       <td>
         Allows you to remove a stroke end listener
       </td>
-      <td>`CanvasStrokeEndHandler`</td>
+      <td>`CanvasStrokeEndHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section4");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 4</u>.</td>
     </tr>
     <tr>
-      <td>`addHoverPixelChangeListener(listener: CanvasHoverPixelChangeHandler)`</td>
+      <td>`addHoverPixelChangeListener`</td>
       <td>
         Allows you to listen to hover pixel change events
       </td>
       <td>
-        `CanvasHoverPixelChangeHandler`
-        ```ts
-        export type CanvasHoverPixelChangeHandler = ({
-          indices: {
-            rowIndex: number;
-            columnIndex: number;
-          } | null
-        }) => void;
-        ```
+        `CanvasHoverPixelChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section5");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 5</u>.
+
       </td>
     </tr>
     <tr>
-      <td>`removeHoverPixelChangeListener(listener: CanvasHoverPixelChangeHandler)`</td>
+      <td>`removeHoverPixelChangeListener`</td>
       <td>
         Allows you to remove pixel change listener
       </td>
-      <td>`CanvasHoverPixelChangeHandler`</td>
+      <td>`CanvasHoverPixelChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section5");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 5</u>.</td>
     </tr>
      <tr>
-      <td>`addCanvasElementEventListener(event: string, listener: EventListenerOrEventListenerObject) `</td>
+      <td>`addCanvasElementEventListener`</td>
       <td>
         Allows you to directly add event listeners to the canvas element (E.g. `mousemove`)
       </td>
-      <td>`string`, `EventListenerOrEventListenerObject`</td>
+      <td>`string`, `EventListenerOrEventListenerObject` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section6");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 6</u>.</td>
     </tr>
      <tr>
-      <td>`removeCanvasElementEventListener(event: string, listener: EventListenerOrEventListenerObject)`</td>
+      <td>`removeCanvasElementEventListener`</td>
       <td>
         Allows you to directly remove event listeners from the canvas element
       </td>
-      <td>`string`, `EventListenerOrEventListenerObject`</td>
+      <td>`string`, `EventListenerOrEventListenerObject` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section6");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 6</u>.</td>
+    </tr>
+    <tr>
+      <td>`addCanvasInfoChangeListener`</td>
+      <td>
+        Allows you to listen to canvas info `panZoom`, `topLeftCornerOffset`, `topRightCornerOffset`, `bottomLeftCornerOffset`, `bottomRightCornerOffset`, `gridSquareSize` change events
+      </td>
+      <td>`CanvasInfoChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section7");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 7</u>.</td>
+    </tr>
+     <tr>
+      <td>`removeCanvasInfoChangeListener`</td>
+      <td>
+        Allows you to remove listeners of canvas info change events
+      </td>
+      <td>`CanvasInfoChangeHandler` For more information about the type, please refer to
+        <u onClick={() => {
+          const el = document.getElementById("section7");
+          if (el) {
+            el.scrollIntoView({ behavior: "smooth" });
+          }
+        }} style={{cursor: "pointer"}}>section 7</u>.</td>
     </tr>
 
   </tbody>
@@ -418,32 +432,244 @@ The events that you can listen to are:
 
 ### Examples
 
-#### 1. Data change listener `addDataChangeListener`, `removeDataChangeListener`
+<div id="section1"></div>
+#### 1. Data change listener
+
+`addDataChangeListener`, `removeDataChangeListener`
 
 With data change listeners, you can observe the changes when the user draws on the canvas.
 You can check the `delta` parameter to see the exact changes that happened on the canvas.
 
+The params you should pass to the listener is `CanvasDataChangeParams`:
+
+```ts
+export type CanvasDataChangeParams = {
+  isLocalChange: boolean;
+  data: DottingData;
+  layerId: string;
+  delta?: CanvasDelta;
+};
+
+export type CanvasDataChangeHandler = (params: CanvasDataChangeParams) => void;
+```
+
+`DottingData` is a map of `rowIndex` to `columnIndex` to `PixelData`
+It contains information about the current colored areas of the canvas:
+
+```ts
+export type DottingData = Map<number, Map<number, PixelData>>;
+
+export type PixelData = {
+  color: string;
+};
+```
+
+`CanvasDelta` is an object that contains information about the changes that happened on the canvas.
+The `modifiedPixels` tells you what pixels have been modified.
+The `addedOrDeletedRows` and `addedOrDeletedColumns` tell you what rows and columns have been added or deleted.
+
+```ts
+export type CanvasDelta = {
+  modifiedPixels: Array<PixelModifyItem>;
+  addedOrDeletedRows?: Array<{
+    isDelete: boolean;
+    index: number;
+  }>;
+  addedOrDeletedColumns?: Array<{
+    isDelete: boolean;
+    index: number;
+  }>;
+};
+```
+
 <DataChangeListener />
 
-#### 2. Stroke end listener `addStrokeEndListener`, `removeStrokeEndListener`
+<div id="section2"></div>
+#### 2. Grid Change listener
 
-With stroke end related listeners, you can observer the changes when the user ends the stroke.
+`addGridChangeListener`, `removeGridChangeListener`
+
+With grid change listeners, you can observe changes in the grids
+
+The params you should pass to the listener is `CanvasGridChangeParams`.
+With the canvas grid change params, you can know the dimensions and the 4 indices of the canvas grid.
+
+```ts
+export type CanvasGridChangeParams = {
+  dimensions: {
+    columnCount: number;
+    rowCount: number;
+  };
+  indices: {
+    topRowIndex: number;
+    bottomRowIndex: number;
+    leftColumnIndex: number;
+    rightColumnIndex: number;
+  };
+};
+
+export type CanvasGridChangeHandler = (params: CanvasGridChangeParams) => void;
+```
+
+<br />
+
+<div id="section3"></div>
+#### 3. Brush Change Listener
+
+`addBrushChangeListener`, `removeBrushChangeListener`
+
+Brush change listeners allows you to observe the changes when the user changes the brush tool or the brush color.
+The parameter you should pass to the listener is defiend as below
+
+```ts
+export type CanvasBrushChangeParams = {
+  brushColor: string;
+  brushTool: BrushTool;
+};
+
+export type CanvasBrushChangeHandler = (
+  params: CanvasBrushChangeParams,
+) => void;
+```
+
+The brush tool is an enum that you can import from the library.
+Currently we have four tools
+
+```ts
+export enum BrushTool {
+  DOT = "DOT",
+  ERASER = "ERASER",
+  PAINT_BUCKET = "PAINT_BUCKET",
+  SELECT = "SELECT",
+}
+```
+
+<br />
+
+<div id="section4"></div>
+#### 4. Stroke end listener{" "}
+
+`addStrokeEndListener`, `removeStrokeEndListener`
+
+With stroke end related listeners, you can observe the changes when the user ends the stroke.
+
+The stroke end listener tells you whate pixels were stroked and what tool was used for stroking them
+Additionally you can get the `DottingData` which is a map of `rowIndex` to `columnIndex` to `PixelData`
+
+The params you should pass to the listener is `CanvasStrokeEndParams`:
+
+```ts
+export type CanvasStrokeEndParams = {
+  strokedPixels: Array<ColorChangeItem>;
+  data: DottingData;
+  strokeTool: BrushTool;
+};
+
+export type CanvasStrokeEndHandler = (params: CanvasStrokeEndParams) => void;
+```
+
+The `ColorChangeItem` is defined as below.
+You are able to get the previous color and the current color of the pixel.
+
+```ts
+export interface ColorChangeItem {
+  rowIndex: number;
+  columnIndex: number;
+  color: string;
+  previousColor: string;
+}
+```
+
+The `DottingData` is defined as below.
+It is a map of `rowIndex` to `columnIndex` to `PixelData`.
+
+```ts
+export type DottingData = Map<number, Map<number, PixelData>>;
+export type PixelData = {
+  color: string;
+};
+```
 
 <StrokeListener />
 
-#### 3. Hover Pixel Change Listener `addHoverPixelChangeListener`, `removeHoverPixelChangeListener`
+<div id="section5"></div>
+#### 5. Hover Pixel Change Listener{" "}
+
+`addHoverPixelChangeListener`, `removeHoverPixelChangeListener`
 
 With the hover pixel change listener, you can observe the changes when the user hovers over the canvas.
 When there is no hovered pixel, the return value will be `null`
 
+The params you should pass to the listener is `CanvasHoverPixelChangeHandler`:
+
+```ts
+export type CanvasHoverPixelChangeHandler = ({
+  indices: {
+    rowIndex: number;
+    columnIndex: number;
+  } | null
+}) => void;
+```
+
 <HoverPixelListener />
 
-#### 4. Canvas Element Custom Event Listener `addCanvasElementEventListener`, `removeCanvasElementEventListener`
+<div id="section6"></div>
+#### 6. Canvas Element Custom Event Listener
+
+`addCanvasElementEventListener`, `removeCanvasElementEventListener`
 
 You can also directly add event listeners to the canvas element.
 This is useful when you want to listen to events that are not provided by the library.
 
+The parameter you should pass to the listener is `CanvasElementEventParams`:
+
+```ts
+export type CanvasElementEventParams = {
+  eventName: string;
+  listener: EventListenerOrEventListenerObject;
+};
+```
+
 <CanvasElementEvents />
+
+<div id="section7"></div>
+#### 7. Canvas Info Change Event Listener
+
+`addCanvasElementEventListener`,`removeCanvasElementEventListener`
+
+You can listen to canvas info change events with `addCanvasInfoChangeListener`.
+The info you can get from the event is:
+
+```ts
+export type CanvasInfoChangeParams = {
+  panZoom: PanZoom;
+  topLeftCornerOffset: Coord;
+  topRightCornerOffset: Coord;
+  bottomLeftCornerOffset: Coord;
+  bottomRightCornerOffset: Coord;
+  gridSquareSize: number;
+};
+```
+
+The PanZoom object is:
+
+```ts
+export type PanZoom = {
+  scale: number;
+  offset: Coord;
+};
+```
+
+and the Coord object is:
+
+```ts
+export interface Coord {
+  x: number;
+  y: number;
+}
+```
+
+<CanvasInfoChangeListener />
 
 <div className="subheading">Example Source Codes</div>
 

--- a/stories/useHandlersComponents/CanvasInfoChangeListener.tsx
+++ b/stories/useHandlersComponents/CanvasInfoChangeListener.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import {
-  CanvasHoverPixelChangeHandler,
   CanvasInfoChangeHandler,
 } from "../../src/components/Canvas/types";
 import Dotting, { DottingRef } from "../../src/components/Dotting";

--- a/stories/useHandlersComponents/CanvasInfoChangeListener.tsx
+++ b/stories/useHandlersComponents/CanvasInfoChangeListener.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import {
+  CanvasHoverPixelChangeHandler,
+  CanvasInfoChangeHandler,
+} from "../../src/components/Canvas/types";
+import Dotting, { DottingRef } from "../../src/components/Dotting";
+import useHandlers from "../../src/hooks/useHandlers";
+import { PanZoom } from "../../src/utils/types";
+
+const CanvasInfoChangeListener = () => {
+  const ref = useRef<DottingRef>(null);
+  const {
+    addCanvasInfoChangeEventListener,
+    removeCanvasInfoChangeEventListener,
+  } = useHandlers(ref);
+  const [canvasPanZoom, setCanvasPanZoom] = useState<PanZoom | null>(null);
+  const [gridSquareSize, setGridSquareSize] = useState<number>(0);
+  const [topLeftCornerOffset, setTopLeftCornerOffset] =
+    useState<{
+      x: number;
+      y: number;
+    } | null>(null);
+
+  useEffect(() => {
+    const handleHoverPixelChangeHandler: CanvasInfoChangeHandler = ({
+      panZoom,
+      topLeftCornerOffset,
+      topRightCornerOffset,
+      bottomLeftCornerOffset,
+      bottomRightCornerOffset,
+      gridSquareSize,
+    }) => {
+      setCanvasPanZoom(panZoom);
+      setGridSquareSize(gridSquareSize);
+      setTopLeftCornerOffset(topLeftCornerOffset);
+    };
+
+    addCanvasInfoChangeEventListener(handleHoverPixelChangeHandler);
+    return () => {
+      removeCanvasInfoChangeEventListener(handleHoverPixelChangeHandler);
+    };
+  }, []);
+  return (
+    <div
+      style={{
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        fontFamily: `'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif`,
+      }}
+    >
+      <Dotting ref={ref} width={"100%"} height={300} />
+      <div
+        style={{
+          marginTop: 25,
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+          marginBottom: 50,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <strong>Current Scale</strong>
+          {canvasPanZoom && <div>{canvasPanZoom.scale}</div>}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <strong>Current Offset</strong>
+          {canvasPanZoom && (
+            <div>
+              x : {canvasPanZoom.offset.x}, y: {canvasPanZoom.offset.y}
+            </div>
+          )}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <strong>Top Left Corner Canvas Offset</strong>
+          {canvasPanZoom && (
+            <div>
+              x : {topLeftCornerOffset.x}, y: {topLeftCornerOffset.y}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CanvasInfoChangeListener;

--- a/stories/useHandlersComponents/index.ts
+++ b/stories/useHandlersComponents/index.ts
@@ -1,8 +1,8 @@
 import CanvasElementEvents from "./CanvasElementEvents";
+import CanvasInfoChangeListener from "./CanvasInfoChangeListener";
 import DataChangeListener from "./DataChangeListener";
 import HoverPixelListener from "./HoverPixelListener";
 import StrokeListener from "./StrokeListener";
-import CanvasInfoChangeListener from "./CanvasInfoChangeListener";
 
 export {
   StrokeListener,

--- a/stories/useHandlersComponents/index.ts
+++ b/stories/useHandlersComponents/index.ts
@@ -2,10 +2,12 @@ import CanvasElementEvents from "./CanvasElementEvents";
 import DataChangeListener from "./DataChangeListener";
 import HoverPixelListener from "./HoverPixelListener";
 import StrokeListener from "./StrokeListener";
+import CanvasInfoChangeListener from "./CanvasInfoChangeListener";
 
 export {
   StrokeListener,
   HoverPixelListener,
   CanvasElementEvents,
   DataChangeListener,
+  CanvasInfoChangeListener,
 };


### PR DESCRIPTION
🚀 [Resolves #78 ]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

https://github.com/hunkim98/dotting/assets/57612141/076bd51c-f5b8-443d-b4ca-71cf8769c2eb


<br/>

### Changes

<!-- Name a title to your changes -->

## Implement canvas info change handler

- _[🪝Hooks] Added an additional handler in `useHandlers` hook_

  - Now users can listen to canvas info change through `useHandlers` hook

- _[🎨Component] Create emit event functions for emitting canvas info changes_

  - I created functions to emit change events for `panZoom`, `topLeftCornerOffset`, `topRightCornerOffset`, `bottomLeftCornerOffset`, `bottomRightCornerOffset`, and `gridSquareSize` 
  - The reason I emit change events for those specific values is because I am further trying develop a feature where users can manipulate a foreground canvas or a background canvas.

- _[📒Docs] Refactor `useHandlers` hook storybook_

  - I made the storybook for `useHandlers` more readable


<br/>

## Notes

This PR is connected with #77 and #76 
<!-- Write a note if you have any -->
<br/>

## Next Up?

<!-- Write your next plans if you have any -->
