### PR TITLE
Feature: Expose mouse event for user manipulation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-🚀 [Resolves: #]
+🚀 [Resolves #]
 
 ### Preview
 

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -71,7 +71,6 @@ import {
   convertCartesianToScreen,
   diffPoints,
   getScreenPoint,
-  getWorldPoint,
   lerpRanges,
 } from "../../utils/math";
 import {
@@ -83,7 +82,6 @@ import {
   convertWorldPosAreaToPixelGridArea,
   returnScrollOffsetFromMouseOffset,
   getDoesAreaOverlapPixelgrid,
-  getPointFromTouch,
   getCenterCartCoordFromTwoTouches,
 } from "../../utils/position";
 import Queue from "../../utils/queue";

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -2480,7 +2480,6 @@ export default class Editor extends EventDispatcher {
         if (buttonDirection) {
           this.extensionPoint.direction = buttonDirection;
           this.mouseMode = MouseMode.EXTENDING;
-          // touchy(this.element, addEvent, "mousemove", this.handleExtension);
         }
       }
     }
@@ -2488,10 +2487,8 @@ export default class Editor extends EventDispatcher {
     if (this.mouseMode === MouseMode.PANNING) {
       if (evt.touches && evt.touches.length > 1) {
         this.mouseMode = MouseMode.PINCHZOOMING;
-        // touchy(this.element, addEvent, "mousemove", this.handlePinchZoom);
       } else {
         this.mouseMode = MouseMode.PANNING;
-        // touchy(this.element, addEvent, "mousemove", this.handlePanning);
       }
     }
 
@@ -2569,6 +2566,14 @@ export default class Editor extends EventDispatcher {
     this.styleMouseCursor(mouseCartCoord);
 
     if (this.mouseMode === MouseMode.NULL) {
+      if (this.brushTool === BrushTool.SELECT) {
+        const selectedArea = this.interactionLayer.getSelectedArea();
+        if (selectedArea) {
+          this.gridLayer.render();
+          this.gridLayer.renderSelection(selectedArea);
+        }
+        return;
+      }
       // just show hover pixel, and show hovered button
       const rowIndices = Array.from(this.dataLayer.getRowKeyOrderMap().keys());
       // columnKeyOrderMap is a sorted map of columnKeys
@@ -2611,6 +2616,7 @@ export default class Editor extends EventDispatcher {
 
       const buttonDirection = this.detectButtonClicked(mouseCartCoord);
       this.gridLayer.setHoveredButton(buttonDirection);
+
       this.renderGridLayer();
     } else if (this.mouseMode == MouseMode.EXTENDING) {
       if (this.gridLayer.getIsGridFixed()) {
@@ -3162,6 +3168,10 @@ export default class Editor extends EventDispatcher {
     this.pinchZoomDiff = undefined;
     this.gridLayer.setHoveredButton(null);
     this.renderGridLayer();
+    const selectedArea = this.interactionLayer.getSelectedArea();
+    if (selectedArea) {
+      this.gridLayer.renderSelection(selectedArea);
+    }
     // we make mouse down world position null
     this.mouseDownWorldPos = null;
     this.mouseDownPanZoom = null;
@@ -3182,6 +3192,10 @@ export default class Editor extends EventDispatcher {
     }
     this.gridLayer.setHoveredButton(null);
     this.renderGridLayer();
+    const selectedArea = this.interactionLayer.getSelectedArea();
+    if (selectedArea) {
+      this.gridLayer.renderSelection(selectedArea);
+    }
     return;
   }
 

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -2506,14 +2506,17 @@ export default class Editor extends EventDispatcher {
     const columnKeys = getColumnKeysFromData(data);
     const sortedRowKeys = rowKeys.sort((a, b) => a - b);
     const sortedColumnKeys = columnKeys.sort((a, b) => a - b);
-    const { includedPixelsIndices } = convertWorldPosAreaToPixelGridArea(
+    const includedPixelsIndices = convertWorldPosAreaToPixelGridArea(
       selectedArea,
       rowCount,
       columnCount,
       this.gridSquareLength,
       sortedRowKeys,
       sortedColumnKeys,
-    );
+    )?.includedPixelsIndices;
+    if (!includedPixelsIndices) {
+      return [];
+    }
     const { topRowIndex, bottomRowIndex, leftColumnIndex, rightColumnIndex } =
       getGridIndicesFromData(data);
     const selectedAreaPixels: Array<ColorChangeItem> = [];

--- a/src/components/Canvas/config.ts
+++ b/src/components/Canvas/config.ts
@@ -29,8 +29,10 @@ export const DefaultPixelDataDimensions = {
 
 export enum MouseMode {
   PANNING = "PANNING",
+  PINCHZOOMING = "PINCHZOOMING",
   EXTENDING = "EXTENDING",
   DRAWING = "DRAWING",
+  NULL = "NULL",
 }
 
 export const DefaultZoomSensitivity = 200;

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -28,6 +28,8 @@ import {
   PixelModifyItem,
 } from "./Canvas/types";
 import { validateLayers } from "../utils/data";
+import { FakeMouseEvent } from "../utils/testUtils";
+import { TouchyEvent } from "../utils/touch";
 
 export interface DottingProps {
   width: number | string;
@@ -136,6 +138,10 @@ export interface DottingRef {
     data: Array<Array<PixelModifyItem>>;
   }>;
   setLayers: (layers: Array<LayerProps>) => void;
+  // for manipulating innate mouse events
+  onMouseDown: (e: { offsetX: number; offsetY: number }) => void;
+  onMouseMove: (e: { offsetX: number; offsetY: number }) => void;
+  onMouseUp: (e: { offsetX: number; offsetY: number }) => void;
 }
 
 // forward ref makes the a ref used in a FC component used in the place that uses the FC component
@@ -844,6 +850,30 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
     [editor],
   );
 
+  const onMouseDown = useCallback(
+    (e: { offsetX: number; offsetY: number }) => {
+      const fakeMouseEvent = new FakeMouseEvent("mousedown", e);
+      editor?.onMouseDown(fakeMouseEvent as TouchyEvent);
+    },
+    [editor],
+  );
+
+  const onMouseMove = useCallback(
+    (e: { offsetX: number; offsetY: number }) => {
+      const fakeMouseEvent = new FakeMouseEvent("mousemove", e);
+      editor?.onMouseMove(fakeMouseEvent as TouchyEvent);
+    },
+    [editor],
+  );
+
+  const onMouseUp = useCallback(
+    (e: { offsetX: number; offsetY: number }) => {
+      const fakeMouseEvent = new FakeMouseEvent("mouseup", e);
+      editor?.onMouseUp(fakeMouseEvent as TouchyEvent);
+    },
+    [editor],
+  );
+
   // useImperativeHandle makes the ref used in the place that uses the FC component
   // We will make our DotterRef manipulatable with the following functions
   useImperativeHandle(
@@ -895,6 +925,10 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       getLayers,
       getLayersAsArray,
       setLayers,
+      // for manipulating innate mouse events
+      onMouseDown,
+      onMouseMove,
+      onMouseUp,
     }),
     [
       // for useDotting
@@ -942,6 +976,10 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       getLayers,
       getLayersAsArray,
       setLayers,
+      // for manipulating innate mouse events
+      onMouseDown,
+      onMouseMove,
+      onMouseUp,
     ],
   );
 

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -28,7 +28,6 @@ import {
   PixelModifyItem,
 } from "./Canvas/types";
 import { validateLayers } from "../utils/data";
-import { FakeMouseEvent } from "../utils/testUtils";
 import { TouchyEvent } from "../utils/touch";
 
 export interface DottingProps {

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -852,7 +852,10 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
 
   const onMouseDown = useCallback(
     (e: { offsetX: number; offsetY: number }) => {
-      const fakeMouseEvent = new FakeMouseEvent("mousedown", e);
+      const fakeMouseEvent = new MouseEvent("mousedown", {
+        clientX: e.offsetX,
+        clientY: e.offsetY,
+      });
       editor?.onMouseDown(fakeMouseEvent as TouchyEvent);
     },
     [editor],
@@ -860,7 +863,10 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
 
   const onMouseMove = useCallback(
     (e: { offsetX: number; offsetY: number }) => {
-      const fakeMouseEvent = new FakeMouseEvent("mousemove", e);
+      const fakeMouseEvent = new MouseEvent("mousemove", {
+        clientX: e.offsetX,
+        clientY: e.offsetY,
+      });
       editor?.onMouseMove(fakeMouseEvent as TouchyEvent);
     },
     [editor],
@@ -868,7 +874,10 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
 
   const onMouseUp = useCallback(
     (e: { offsetX: number; offsetY: number }) => {
-      const fakeMouseEvent = new FakeMouseEvent("mouseup", e);
+      const fakeMouseEvent = new MouseEvent("mouseup", {
+        clientX: e.offsetX,
+        clientY: e.offsetY,
+      });
       editor?.onMouseUp(fakeMouseEvent as TouchyEvent);
     },
     [editor],

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -220,6 +220,7 @@ export const getInBetweenPixelIndicesfromCoords = (
   gridSquareLength: number,
   data: DottingData,
 ) => {
+  if (!previousCoord || !currentCoord) return [];
   if (
     Math.abs(currentCoord.x - previousCoord.x) >= gridSquareLength ||
     Math.abs(currentCoord.y - previousCoord.y) >= gridSquareLength

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -110,7 +110,7 @@ export const calculateNewPanZoomFromPinchZoom = (
     }
 
     const deltaX = prevPinchZoomDiff - pinchZoomCurrentDiff;
-    const zoom = 1 - (deltaX * 2) / zoomSensitivity;
+    const zoom = 1 - (deltaX * 2) / (zoomSensitivity * 2);
     const newScale = panZoom.scale * zoom;
     if (minScale > newScale || newScale > maxScale) {
       return;
@@ -144,6 +144,31 @@ export const getMouseCartCoord = (
   const point = getPointFromTouchyEvent(evt, element, panZoom);
   const pointCoord = { x: point.offsetX, y: point.offsetY };
   const diffPointsOfMouseOffset = getWorldPoint(pointCoord, panZoom);
+  const mouseCartCoord = diffPoints(diffPointsOfMouseOffset, {
+    x: element.width / dpr / 2,
+    y: element.height / dpr / 2,
+  });
+  return mouseCartCoord;
+};
+
+export const getCenterCartCoordFromTwoTouches = (
+  evt: TouchyEvent,
+  element: HTMLCanvasElement,
+  panZoom: PanZoom,
+  dpr: number,
+) => {
+  evt.preventDefault();
+  if (evt.touches && evt.touches.length < 2) return null;
+  if (evt.touches.length > 2) return null;
+  const touch1 = evt.touches[0];
+  const touch2 = evt.touches[1];
+  const touch1Point = getPointFromTouch(touch1, element, panZoom);
+  const touch2Point = getPointFromTouch(touch2, element, panZoom);
+  const touchCenterPos = {
+    x: (touch1Point.offsetX + touch2Point.offsetX) / 2,
+    y: (touch1Point.offsetY + touch2Point.offsetY) / 2,
+  };
+  const diffPointsOfMouseOffset = getWorldPoint(touchCenterPos, panZoom);
   const mouseCartCoord = diffPoints(diffPointsOfMouseOffset, {
     x: element.width / dpr / 2,
     y: element.height / dpr / 2,

--- a/stories/custom/CustomExample.tsx
+++ b/stories/custom/CustomExample.tsx
@@ -14,6 +14,7 @@ const CustomExample = () => {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
+        position: "relative",
       }}
     >
       <Dotting ref={ref} width={"100%"} height={300} />
@@ -24,6 +25,34 @@ const CustomExample = () => {
       >
         hi
       </button> */}
+      {/* <div
+        style={{
+          position: "absolute",
+          width: "100%",
+          height: 300,
+          backgroundColor: "rgba(0,0,0,0.5)",
+          top: 0,
+          left: 0,
+        }}
+        onMouseDown={e => {
+          ref.current.onMouseDown({
+            offsetX: e.nativeEvent.offsetX,
+            offsetY: e.nativeEvent.offsetY,
+          });
+        }}
+        onMouseMove={e => {
+          ref.current.onMouseMove({
+            offsetX: e.nativeEvent.offsetX,
+            offsetY: e.nativeEvent.offsetY,
+          });
+        }}
+        onMouseUp={e => {
+          ref.current.onMouseUp({
+            offsetX: e.nativeEvent.offsetX,
+            offsetY: e.nativeEvent.offsetY,
+          });
+        }}
+      ></div> */}
       <div>
         {[
           "#FF0000",

--- a/stories/useBrushComponents/ChangeBrushPattern.tsx
+++ b/stories/useBrushComponents/ChangeBrushPattern.tsx
@@ -79,6 +79,7 @@ const ChangeBrushPattern = () => {
           {patterns.map((pattern, index) => {
             return (
               <div
+                key={index}
                 style={{
                   display: "flex",
                   backgroundColor: selectedPatternIndex === index ? "grey" : "",
@@ -94,17 +95,19 @@ const ChangeBrushPattern = () => {
                   changeBrushPattern(pattern);
                 }}
               >
-                {pattern.map(row => {
+                {pattern.map((row, key) => {
                   return (
                     <div
+                      key={key}
                       style={{
                         display: "flex",
                         flexDirection: "column",
                       }}
                     >
-                      {row.map(cell => {
+                      {row.map((cell, idx) => {
                         return (
                           <div
+                            key={idx}
                             style={{
                               width: 10,
                               height: 10,

--- a/stories/useBrushComponents/ChangeBrushTool.tsx
+++ b/stories/useBrushComponents/ChangeBrushTool.tsx
@@ -26,10 +26,39 @@ const ChangeBrushTool = () => {
         flexDirection: "column",
         alignItems: "center",
         fontFamily: `'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif`,
+        position: "relative",
         marginBottom: 50,
       }}
     >
       <Dotting ref={ref} width={"100%"} height={300} />
+      {/* <div
+        style={{
+          position: "absolute",
+          width: "100%",
+          height: 300,
+          backgroundColor: "rgba(0,0,0,0.5)",
+          top: 0,
+          left: 0,
+        }}
+        onMouseDown={e => {
+          ref.current.onMouseDown({
+            offsetX: e.nativeEvent.offsetX,
+            offsetY: e.nativeEvent.offsetY,
+          });
+        }}
+        onMouseMove={e => {
+          ref.current.onMouseMove({
+            offsetX: e.nativeEvent.offsetX,
+            offsetY: e.nativeEvent.offsetY,
+          });
+        }}
+        onMouseUp={e => {
+          ref.current.onMouseUp({
+            offsetX: e.nativeEvent.offsetX,
+            offsetY: e.nativeEvent.offsetY,
+          });
+        }}
+      ></div> */}
       <div
         style={{
           display: "flex",


### PR DESCRIPTION
🚀 [Resolves #81 ]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

<br/>

### Changes

<!-- Name a title to your changes -->

## Expose mouse event for user manipulation

- _[🎨Component] Allow `onMouseDown` `onMouseMove` `onMouseUp` to be exposed_

  - Previously mouse operations were hidden inside the `Editor` class. Thus, the mouse events were unable to be manipulated by users. For instance a user could not emit the inner mouse event with code
  - However, allowing users to manipulate the mouse events manually was necessary especially when a user decides to overlay a DOM or a transparent screen above `Dotting` component
  - I am currently developing a iPad app with `Dotting` and I needed to overlay a transparent screen on top of `Dotting` for manipulation.
  - Now users can call the inner mouse event logic through code


## Refactor `onMouseDown` `onMouseMove` for better readability

- _[🎨Component] Refactor mouse event code for better readability_

  - Previously the mouse event code was difficult to understand. This complexity could perplex anyone who tries to decipher the mouse logic
  - I refactored the code a little according to `mouseMode` and `brushTool` for better readability.

<br/>

## Notes

<!-- Write a note if you have any -->

This is a feature necessary for dotting iPad app.

<br/>

## Next Up?

<!-- Write your next plans if you have any -->
