### PR TITLE
Feature: Set zoom scale to adequate scale of the inputted dimensions(rowCount, columnCount)

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -427,18 +427,7 @@ export default class Editor extends EventDispatcher {
     this.gridLayer.setGridSquareLength(length);
     this.interactionLayer.setGridSquareLength(length);
     this.dataLayer.setGridSquareLength(length);
-    this.adjustMinScaleByGridSquareLength(length);
     this.renderAll();
-  }
-
-  adjustMinScaleByGridSquareLength(gridSquareLength: number) {
-    if (this.staticMinScale === null) {
-      // we can freely dynamically adjust the min scale
-      // we should let min scale be the minimum scale that can fit the canvas
-      // the minimum grid square length can be 1px
-      const newScale = 1 / this.gridSquareLength;
-      this.minScale = newScale;
-    }
   }
 
   /**

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -97,8 +97,6 @@ export default class Editor extends EventDispatcher {
   private zoomSensitivity: number = DefaultZoomSensitivity;
   private maxScale: number = DefaultMaxScale;
   private minScale: number = 1 / DefaultGridSquareLength;
-  private staticMinScale: number | null = null;
-  private staticMaxScale: number | null = null;
   private extensionAllowanceRatio = 2;
   private pinchZoomDiff: number | null = null;
   private width: number;
@@ -439,10 +437,9 @@ export default class Editor extends EventDispatcher {
     if (minScale === undefined) {
       return;
     }
-    if (this.staticMaxScale !== null && minScale > this.staticMaxScale) {
+    if (minScale > this.maxScale) {
       throw new Error("minScale cannot be greater than maxScale");
     }
-    this.staticMinScale = minScale;
     this.minScale = minScale;
   }
 
@@ -455,10 +452,9 @@ export default class Editor extends EventDispatcher {
     if (maxScale === undefined) {
       return;
     }
-    if (this.staticMinScale !== null && maxScale < this.staticMinScale) {
+    if (maxScale < this.minScale) {
       throw new Error("maxScale cannot be less than minScale");
     }
-    this.staticMaxScale = maxScale;
     this.maxScale = maxScale;
   }
 

--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -428,11 +428,6 @@ export default class Editor extends EventDispatcher {
     this.renderAll();
   }
 
-  /**
-   * @description This function will set the static min scale of the canvas
-   * @param minScale
-   * @returns
-   */
   setMinScale(minScale: number) {
     if (minScale === undefined) {
       return;
@@ -443,11 +438,6 @@ export default class Editor extends EventDispatcher {
     this.minScale = minScale;
   }
 
-  /**
-   * @description This function will set the static max scale of the canvas
-   * @param maxScale
-   * @returns
-   */
   setMaxScale(maxScale: number) {
     if (maxScale === undefined) {
       return;

--- a/src/components/Canvas/types.ts
+++ b/src/components/Canvas/types.ts
@@ -94,7 +94,6 @@ export type CanvasGridChangeHandler = (params: CanvasGridChangeParams) => void;
 
 export type CanvasStrokeEndParams = {
   strokedPixels: Array<ColorChangeItem>;
-  data: DottingData;
   strokeTool: BrushTool;
 };
 

--- a/src/components/Dotting.tsx
+++ b/src/components/Dotting.tsx
@@ -436,9 +436,16 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
   ]);
 
   useEffect(() => {
-    if (!gridCanvas || !interactionCanvas || !dataCanvas || !backgroundCanvas) {
+    if (
+      !gridCanvas ||
+      !interactionCanvas ||
+      !dataCanvas ||
+      !backgroundCanvas ||
+      !containerRef.current
+    ) {
       return;
     }
+    const { width, height } = containerRef.current.getBoundingClientRect();
     // this only happens once
     const validatedLayers =
       props.initLayers && validateLayers(props.initLayers)
@@ -452,6 +459,8 @@ const Dotting = forwardRef<DottingRef, DottingProps>(function Dotting(
       backgroundCanvas,
       initLayers: validatedLayers,
       gridSquareLength: props.gridSquareLength,
+      width,
+      height,
     });
     editor.setIsGridFixed(props.isGridFixed);
     editor.setIsInteractionApplicable(props.isInteractionApplicable);

--- a/src/test/Editor/color.pixels.area.test.tsx
+++ b/src/test/Editor/color.pixels.area.test.tsx
@@ -18,8 +18,8 @@ describe("test for color pixels area", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -29,7 +29,6 @@ describe("test for color pixels area", () => {
       editor.onKeyDown(e);
     });
 
-    mockEditor.setSize(800, 800);
     editor = mockEditor;
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();

--- a/src/test/Editor/color.pixels.area.test.tsx
+++ b/src/test/Editor/color.pixels.area.test.tsx
@@ -18,6 +18,8 @@ describe("test for color pixels area", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/src/test/Editor/color.pixels.test.tsx
+++ b/src/test/Editor/color.pixels.test.tsx
@@ -18,8 +18,8 @@ describe("test for color pixel method in Editor", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -29,7 +29,6 @@ describe("test for color pixel method in Editor", () => {
       editor.onKeyDown(e);
     });
 
-    mockEditor.setSize(800, 800);
     editor = mockEditor;
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();

--- a/src/test/Editor/color.pixels.test.tsx
+++ b/src/test/Editor/color.pixels.test.tsx
@@ -18,6 +18,8 @@ describe("test for color pixel method in Editor", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/src/test/Editor/draw.test.tsx
+++ b/src/test/Editor/draw.test.tsx
@@ -18,6 +18,8 @@ describe("test for drawing interaction", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/src/test/Editor/draw.test.tsx
+++ b/src/test/Editor/draw.test.tsx
@@ -18,8 +18,8 @@ describe("test for drawing interaction", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -29,7 +29,6 @@ describe("test for drawing interaction", () => {
       editor.onKeyDown(e);
     });
 
-    mockEditor.setSize(800, 800);
     editor = mockEditor;
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();

--- a/src/test/Editor/extension.test.tsx
+++ b/src/test/Editor/extension.test.tsx
@@ -7,6 +7,8 @@ import { FakeMouseEvent } from "../../utils/testUtils";
 describe("test for extension interaction", () => {
   let editor: Editor;
   let canvasElement: HTMLCanvasElement;
+  let scale: number;
+  let offset: { x: number; y: number };
   beforeEach(() => {
     const divElement = document.createElement("div");
     const interactionCanvas = divElement.appendChild(
@@ -17,13 +19,14 @@ describe("test for extension interaction", () => {
     const backgroundCanvas = divElement.appendChild(
       document.createElement("canvas"),
     );
+
     const mockEditor = new Editor({
       gridCanvas,
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -33,8 +36,12 @@ describe("test for extension interaction", () => {
       editor.onKeyDown(e);
     });
 
-    mockEditor.setSize(800, 800);
+    const panZoom = mockEditor.getPanZoom();
+    scale = panZoom.scale;
+    offset = panZoom.offset;
+
     editor = mockEditor;
+    editor.setIsGridFixed(false);
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();
   });
@@ -47,18 +54,19 @@ describe("test for extension interaction", () => {
     const columnCount = editor.getColumnCount();
     const rowCount = editor.getRowCount();
     const gridSquareLength = editor.getGridSquareLength();
+
     // select left top corner
     fireEvent(
       canvasElement,
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -66,14 +74,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -81,14 +89,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     const { topRowIndex, leftColumnIndex } = editor.getGridIndices();
@@ -106,12 +114,12 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -119,14 +127,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -134,14 +142,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     const { bottomRowIndex, rightColumnIndex } = editor.getGridIndices();
@@ -159,12 +167,12 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -172,14 +180,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -187,14 +195,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     const { topRowIndex, rightColumnIndex } = editor.getGridIndices();
@@ -212,12 +220,12 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -225,14 +233,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -240,14 +248,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     const { bottomRowIndex, leftColumnIndex } = editor.getGridIndices();
@@ -265,12 +273,12 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -278,14 +286,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -293,14 +301,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     const { topRowIndex, leftColumnIndex } = editor.getGridIndices();
@@ -318,12 +326,12 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -331,14 +339,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -346,14 +354,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     const { bottomRowIndex, rightColumnIndex } = editor.getGridIndices();
@@ -371,12 +379,12 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -384,14 +392,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -399,14 +407,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 +
-          (gridSquareLength * columnCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 -
-          (gridSquareLength * rowCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
       }),
     );
     const { topRowIndex, rightColumnIndex } = editor.getGridIndices();
@@ -424,12 +432,12 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousedown", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4,
       }),
     );
     fireEvent(
@@ -437,14 +445,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mousemove", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     fireEvent(
@@ -452,14 +460,14 @@ describe("test for extension interaction", () => {
       new FakeMouseEvent("mouseup", {
         offsetX:
           canvasElement.width / 2 -
-          (gridSquareLength * columnCount) / 2 -
-          DefaultButtonHeight / 4 +
-          gridSquareLength,
+          (scale * gridSquareLength * columnCount) / 2 -
+          (scale * DefaultButtonHeight) / 4 +
+          scale * gridSquareLength,
         offsetY:
           canvasElement.height / 2 +
-          (gridSquareLength * rowCount) / 2 +
-          DefaultButtonHeight / 4 -
-          gridSquareLength,
+          (scale * gridSquareLength * rowCount) / 2 +
+          (scale * DefaultButtonHeight) / 4 -
+          scale * gridSquareLength,
       }),
     );
     const { bottomRowIndex, leftColumnIndex } = editor.getGridIndices();

--- a/src/test/Editor/extension.test.tsx
+++ b/src/test/Editor/extension.test.tsx
@@ -22,6 +22,8 @@ describe("test for extension interaction", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/src/test/Editor/set.data.test.tsx
+++ b/src/test/Editor/set.data.test.tsx
@@ -25,6 +25,8 @@ describe("test set data", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/src/test/Editor/set.data.test.tsx
+++ b/src/test/Editor/set.data.test.tsx
@@ -25,8 +25,8 @@ describe("test set data", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -36,7 +36,6 @@ describe("test set data", () => {
       editor.onKeyDown(e);
     });
 
-    mockEditor.setSize(800, 800);
     editor = mockEditor;
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();

--- a/src/test/Editor/set.layers.test.tsx
+++ b/src/test/Editor/set.layers.test.tsx
@@ -25,8 +25,8 @@ describe("test set layers", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -36,7 +36,6 @@ describe("test set layers", () => {
       editor.onKeyDown(e);
     });
 
-    mockEditor.setSize(800, 800);
     editor = mockEditor;
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();

--- a/src/test/Editor/set.layers.test.tsx
+++ b/src/test/Editor/set.layers.test.tsx
@@ -25,6 +25,8 @@ describe("test set layers", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/src/test/Editor/undo.redo.test.tsx
+++ b/src/test/Editor/undo.redo.test.tsx
@@ -24,8 +24,8 @@ describe("test for undo and redo", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -35,8 +35,9 @@ describe("test for undo and redo", () => {
       editor.onKeyDown(e);
     });
 
-    mockEditor.setSize(800, 800);
+    mockEditor.setIsGridFixed(false);
     editor = mockEditor;
+
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();
   });

--- a/src/test/Editor/undo.redo.test.tsx
+++ b/src/test/Editor/undo.redo.test.tsx
@@ -24,6 +24,8 @@ describe("test for undo and redo", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/src/test/interactionLayer/select.test.tsx
+++ b/src/test/interactionLayer/select.test.tsx
@@ -22,8 +22,8 @@ describe("test for select tool", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
-      width: 300,
-      height: 300,
+      width: 800,
+      height: 800,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {
@@ -32,8 +32,6 @@ describe("test for select tool", () => {
     divElement.addEventListener("keydown", (e: any) => {
       editor.onKeyDown(e);
     });
-
-    mockEditor.setSize(800, 800);
     editor = mockEditor;
     // initialize the canvas with select tool selecting all the pixels
     canvasElement = editor.getCanvasElement();

--- a/src/test/interactionLayer/select.test.tsx
+++ b/src/test/interactionLayer/select.test.tsx
@@ -22,6 +22,8 @@ describe("test for select tool", () => {
       interactionCanvas,
       dataCanvas,
       backgroundCanvas,
+      width: 300,
+      height: 300,
     });
     divElement.tabIndex = 1;
     divElement.onmousedown = () => {

--- a/stories/customization/Layers.tsx
+++ b/stories/customization/Layers.tsx
@@ -176,15 +176,15 @@ const Layers = () => {
           initLayers={[
             {
               id: "layer1",
-              data: CreateEmptySquareData(15),
+              data: CreateEmptySquareData(128),
             },
             {
               id: "layer2",
-              data: CreateEmptySquareData(15),
+              data: CreateEmptySquareData(128),
             },
             {
               id: "layer3",
-              data: CreateEmptySquareData(15),
+              data: CreateEmptySquareData(128),
             },
           ]}
         />

--- a/stories/customization/Layers.tsx
+++ b/stories/customization/Layers.tsx
@@ -176,15 +176,15 @@ const Layers = () => {
           initLayers={[
             {
               id: "layer1",
-              data: CreateEmptySquareData(128),
+              data: CreateEmptySquareData(32),
             },
             {
               id: "layer2",
-              data: CreateEmptySquareData(128),
+              data: CreateEmptySquareData(32),
             },
             {
               id: "layer3",
-              data: CreateEmptySquareData(128),
+              data: CreateEmptySquareData(32),
             },
           ]}
         />

--- a/stories/useDottingComponents/SetData.tsx
+++ b/stories/useDottingComponents/SetData.tsx
@@ -2,10 +2,11 @@ import React, { useRef } from "react";
 
 import Dotting, { DottingRef } from "../../src/components/Dotting";
 import useDotting from "../../src/hooks/useDotting";
+import { CreateEmptySquareData } from "../utils/dataCreator";
 
 const SetData = () => {
   const ref = useRef<DottingRef>(null);
-  const { setData } = useDotting(ref);
+  const { setData, setLayers } = useDotting(ref);
 
   return (
     <div
@@ -35,109 +36,32 @@ const SetData = () => {
               background: "none",
             }}
             onClick={() => {
-              setData([
-                [
-                  { rowIndex: 0, columnIndex: 0, color: "" },
-                  { rowIndex: 0, columnIndex: 1, color: "" },
-                  { rowIndex: 0, columnIndex: 2, color: "" },
-                ],
-                [
-                  { rowIndex: 1, columnIndex: 0, color: "" },
-                  { rowIndex: 1, columnIndex: 1, color: "" },
-                  { rowIndex: 1, columnIndex: 2, color: "" },
-                ],
-                [
-                  { rowIndex: 2, columnIndex: 0, color: "" },
-                  { rowIndex: 2, columnIndex: 1, color: "" },
-                  { rowIndex: 2, columnIndex: 2, color: "" },
-                ],
-              ]);
-            }}
-          >
-            Set Data to 3 X 3
-          </button>
-          <button
-            style={{
-              padding: "5px 10px",
-              background: "none",
-            }}
-            onClick={() => {
-              setData([
-                [
-                  { rowIndex: 0, columnIndex: 0, color: "" },
-                  { rowIndex: 0, columnIndex: 1, color: "" },
-                  { rowIndex: 0, columnIndex: 2, color: "" },
-                  { rowIndex: 0, columnIndex: 3, color: "" },
-                ],
-                [
-                  { rowIndex: 1, columnIndex: 0, color: "" },
-                  { rowIndex: 1, columnIndex: 1, color: "" },
-                  { rowIndex: 1, columnIndex: 2, color: "" },
-                  { rowIndex: 1, columnIndex: 3, color: "" },
-                ],
-                [
-                  { rowIndex: 2, columnIndex: 0, color: "" },
-                  { rowIndex: 2, columnIndex: 1, color: "" },
-                  { rowIndex: 2, columnIndex: 2, color: "" },
-                  { rowIndex: 2, columnIndex: 3, color: "" },
-                ],
-                [
-                  { rowIndex: 3, columnIndex: 0, color: "" },
-                  { rowIndex: 3, columnIndex: 1, color: "" },
-                  { rowIndex: 3, columnIndex: 2, color: "" },
-                  { rowIndex: 3, columnIndex: 3, color: "" },
-                ],
-              ]);
-            }}
-          >
-            Set Data to 4 X 4
-          </button>
-          <button
-            style={{
-              padding: "5px 10px",
-              background: "none",
-            }}
-            onClick={() => {
-              setData([
-                [
-                  { rowIndex: 0, columnIndex: 0, color: "" },
-                  { rowIndex: 0, columnIndex: 1, color: "" },
-                  { rowIndex: 0, columnIndex: 2, color: "" },
-                  { rowIndex: 0, columnIndex: 3, color: "" },
-                  { rowIndex: 0, columnIndex: 4, color: "" },
-                ],
-                [
-                  { rowIndex: 1, columnIndex: 0, color: "" },
-                  { rowIndex: 1, columnIndex: 1, color: "" },
-                  { rowIndex: 1, columnIndex: 2, color: "" },
-                  { rowIndex: 1, columnIndex: 3, color: "" },
-                  { rowIndex: 1, columnIndex: 4, color: "" },
-                ],
-                [
-                  { rowIndex: 2, columnIndex: 0, color: "" },
-                  { rowIndex: 2, columnIndex: 1, color: "" },
-                  { rowIndex: 2, columnIndex: 2, color: "" },
-                  { rowIndex: 2, columnIndex: 3, color: "" },
-                  { rowIndex: 2, columnIndex: 4, color: "" },
-                ],
-                [
-                  { rowIndex: 3, columnIndex: 0, color: "" },
-                  { rowIndex: 3, columnIndex: 1, color: "" },
-                  { rowIndex: 3, columnIndex: 2, color: "" },
-                  { rowIndex: 3, columnIndex: 3, color: "" },
-                  { rowIndex: 3, columnIndex: 4, color: "" },
-                ],
-                [
-                  { rowIndex: 4, columnIndex: 0, color: "" },
-                  { rowIndex: 4, columnIndex: 1, color: "" },
-                  { rowIndex: 4, columnIndex: 2, color: "" },
-                  { rowIndex: 4, columnIndex: 3, color: "" },
-                  { rowIndex: 4, columnIndex: 4, color: "" },
-                ],
-              ]);
+              setData(CreateEmptySquareData(5));
             }}
           >
             Set Data to 5 X 5
+          </button>
+          <button
+            style={{
+              padding: "5px 10px",
+              background: "none",
+            }}
+            onClick={() => {
+              setData(CreateEmptySquareData(64));
+            }}
+          >
+            Set Data to 64 X 64
+          </button>
+          <button
+            style={{
+              padding: "5px 10px",
+              background: "none",
+            }}
+            onClick={() => {
+              setData(CreateEmptySquareData(100));
+            }}
+          >
+            Set Data to 100 X 100
           </button>
         </div>
       </div>

--- a/stories/useHandlers.stories.mdx
+++ b/stories/useHandlers.stories.mdx
@@ -561,7 +561,6 @@ The params you should pass to the listener is `CanvasStrokeEndParams`:
 ```ts
 export type CanvasStrokeEndParams = {
   strokedPixels: Array<ColorChangeItem>;
-  data: DottingData;
   strokeTool: BrushTool;
 };
 
@@ -578,16 +577,6 @@ export interface ColorChangeItem {
   color: string;
   previousColor: string;
 }
-```
-
-The `DottingData` is defined as below.
-It is a map of `rowIndex` to `columnIndex` to `PixelData`.
-
-```ts
-export type DottingData = Map<number, Map<number, PixelData>>;
-export type PixelData = {
-  color: string;
-};
 ```
 
 <StrokeListener />

--- a/stories/useHandlersComponents/StrokeListener.tsx
+++ b/stories/useHandlersComponents/StrokeListener.tsx
@@ -15,7 +15,6 @@ const StrokeListener = () => {
   );
   const handleStrokeEnd: CanvasStrokeEndHandler = ({
     strokedPixels,
-    data,
     strokeTool,
   }) => {
     setStrokedPixels(strokedPixels);


### PR DESCRIPTION
🚀 [Resolves #87]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->

https://github.com/hunkim98/dotting/assets/57612141/2311c80b-fc10-4f5f-a65c-b58bb23c9cb8


<br/>

### Changes

<!-- Name a title to your changes -->

## Adjust zoom scale to the inputted dimensions

- _[🎨Component] Create `adjustInitialZoomScale` function for setting an adequate zoom scale for the inputted data_

  - Previously, no matter what the user inputs as the data (`setData`, `setLayers`), the zoom value was always set to 1. However, this did not help when users wanted to see pixel canvas with more than 100 rows or columns.
  - I thus created a function to adequately manipulate the zoom scale for the inputted data. Now, the user will be able to see the whole grid canvas initially


## Optimize onmouseup interaction for drawing actions

- _[🪝Hooks] Remove data params from stroke end listener_

  - Previously, strokeEndListener allowed users to get a new copied `DottingData` every time the user ends their stroke. However, I found that copying the whole data every time the users finishes interaction lagging when the data has more than 100 rows or columns. Thus I removed the `data` prams from `strokeEndListener`

- _[🎨Component] Lessen the usage of `getCopiedData`_

  - I found that there were many places that used `getCopiedData` especially during interaction. This inevitably cause lots of lags when the data was too big. Thus, I decided to not use `getCopiedData` and just use the original data when emitting events.
  - `getCopiedData` is only used when there is a need to copy the current data to the interaction layer.

- _[📒Docs] Update stroke end listener example_




<br/>

## Notes

<!-- Write a note if you have any -->
<br/>

## Next Up?

I am going to find methods to optimize panning and zooming using `drawImage`

<!-- Write your next plans if you have any -->
