### PR TITLE
Fix paint bucket - currently only working with a drag event

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -2643,7 +2643,7 @@ export default class Editor extends EventDispatcher {
 
           // move the pixels to interaction layer
         }
-      } else if (this.brushTool === BrushTool.DOT) {
+      } else if (this.brushTool === BrushTool.DOT || this.brushTool === BrushTool.PAINT_BUCKET) {
         if (pixelIndex) {
           this.drawPixelInInteractionLayer(
             pixelIndex.rowIndex,


### PR DESCRIPTION

🚀 [Resolves #109 ]

### Preview

<!-- Please leave screenshots since they help others understand what you have done -->
N/A

<br/>

### Changes

<!-- Name a title to your changes -->

## Fix paint bucket - currently only working with a drag event

- _[🎨Component] Write a summary of what you have done on hooks_

Right now the paint bucket only works if you drag the cursor after clicking. Just clicking won't work. This commit fixes the problem by adding a missing check in the mouse down handler.

<br/>

## Notes

<!-- Write a note if you have any -->
N/A
<br/>

## Next Up?

<!-- Write your next plans if you have any -->
N/A