### PR TITLE
Fix gridMinimumScale behaviour

### DIFF
--- a/src/components/Canvas/Editor.tsx
+++ b/src/components/Canvas/Editor.tsx
@@ -109,6 +109,7 @@ export default class Editor extends EventDispatcher {
   private topRowIndex: number;
   private leftColumnIndex: number;
   private lastRenderAllCall: number | null = null;
+  private initialIsGridVisible: boolean;
 
   private panZoom: PanZoom = {
     scale: 1,
@@ -482,7 +483,11 @@ export default class Editor extends EventDispatcher {
   }
 
   setIsGridVisible(isGridVisible: boolean) {
-    this.gridLayer.setIsGridVisible(isGridVisible);
+    const initialValue = isGridVisible === undefined || isGridVisible;
+    if (this.initialIsGridVisible === undefined) {
+      this.initialIsGridVisible = initialValue;
+    }
+    this.gridLayer.setIsGridVisible(initialValue);
     this.renderGridLayer();
   }
   // grid related functions ⬆
@@ -1227,10 +1232,12 @@ export default class Editor extends EventDispatcher {
       this.panZoom.offset = correctedOffset;
     }
 
-    if (this.panZoom.scale < GridMinimumScale) {
-      this.gridLayer.setIsGridVisible(false);
-    } else {
-      this.gridLayer.setIsGridVisible(true);
+    if (this.initialIsGridVisible !== undefined && this.initialIsGridVisible) {
+      if (this.panZoom.scale < GridMinimumScale) {
+        this.gridLayer.setIsGridVisible(false);
+      } else {
+        this.gridLayer.setIsGridVisible(true);
+      }
     }
 
     // relay updated information to layers
@@ -2643,7 +2650,10 @@ export default class Editor extends EventDispatcher {
 
           // move the pixels to interaction layer
         }
-      } else if (this.brushTool === BrushTool.DOT || this.brushTool === BrushTool.PAINT_BUCKET) {
+      } else if (
+        this.brushTool === BrushTool.DOT ||
+        this.brushTool === BrushTool.PAINT_BUCKET
+      ) {
         if (pixelIndex) {
           this.drawPixelInInteractionLayer(
             pixelIndex.rowIndex,

--- a/src/components/Canvas/GridLayer.tsx
+++ b/src/components/Canvas/GridLayer.tsx
@@ -19,7 +19,7 @@ import {
 export default class GridLayer extends BaseLayer {
   private columnCount: number;
   private rowCount: number;
-  private isGridVisible = true;
+  private isGridVisible;
   private isGridFixed = false;
   private gridStrokeColor: string;
   private gridStrokeWidth: number;
@@ -109,6 +109,7 @@ export default class GridLayer extends BaseLayer {
   }
 
   setIsGridVisible(isGridVisible: boolean) {
+    console.log(99999, isGridVisible);
     if (isGridVisible !== undefined) {
       this.isGridVisible = isGridVisible;
     }


### PR DESCRIPTION
**Issue:** When isGridVisible={false}, the grid reappeared unexpectedly during canvas interactions like panning or zooming.

**Fix:** Ensured that the grid remains hidden when isGridVisible={false}, regardless of canvas interactions such as panning or zooming. That was caused when GridMinimumScale was introduced. Fixed that behaviour as well.